### PR TITLE
Added ability to stop queue draining to processing pool.

### DIFF
--- a/src/main/java/io/divolte/server/IncomingRequestProcessor.java
+++ b/src/main/java/io/divolte/server/IncomingRequestProcessor.java
@@ -21,6 +21,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import static io.divolte.server.DivolteEventHandler.*;
+import static io.divolte.server.processing.ItemProcessor.ProcessingDirective.*;
 
 @ParametersAreNonnullByDefault
 final class IncomingRequestProcessor implements ItemProcessor<HttpServerExchange> {
@@ -61,7 +62,7 @@ final class IncomingRequestProcessor implements ItemProcessor<HttpServerExchange
     }
 
     @Override
-    public void process(final HttpServerExchange exchange) {
+    public ProcessingDirective process(final HttpServerExchange exchange) {
         final GenericRecord avroRecord = mapper.newRecordFromExchange(exchange);
         final AvroRecordBuffer avroBuffer = AvroRecordBuffer.fromRecord(
                 exchange.getAttachment(PARTY_COOKIE_KEY),
@@ -80,5 +81,6 @@ final class IncomingRequestProcessor implements ItemProcessor<HttpServerExchange
         if (logger.isDebugEnabled()) {
             logger.debug("Incoming request record:\n{}", avroRecord);
         }
+        return CONTINUE;
     }
 }

--- a/src/main/java/io/divolte/server/hdfs/HdfsFlusher.java
+++ b/src/main/java/io/divolte/server/hdfs/HdfsFlusher.java
@@ -1,6 +1,7 @@
 package io.divolte.server.hdfs;
 
 import static io.divolte.server.hdfs.FileCreateAndSyncStrategy.HdfsOperationResult.*;
+import static io.divolte.server.processing.ItemProcessor.ProcessingDirective.*;
 import io.divolte.server.AvroRecordBuffer;
 import io.divolte.server.hdfs.FileCreateAndSyncStrategy.HdfsOperationResult;
 import io.divolte.server.processing.ItemProcessor;
@@ -59,14 +60,16 @@ final class HdfsFlusher implements ItemProcessor<AvroRecordBuffer> {
     }
 
     @Override
-    public void process(AvroRecordBuffer record) {
+    public ProcessingDirective process(AvroRecordBuffer record) {
         if (lastHdfsResult == SUCCESS) {
             lastHdfsResult = fileStrategy.append(record);
         }
+        return CONTINUE;
     }
 
     @Override
-    public void heartbeat() {
+    public ProcessingDirective heartbeat() {
         lastHdfsResult = fileStrategy.heartbeat();
+        return lastHdfsResult == SUCCESS ? CONTINUE : PAUSE;
     }
 }

--- a/src/main/java/io/divolte/server/kafka/KafkaFlusher.java
+++ b/src/main/java/io/divolte/server/kafka/KafkaFlusher.java
@@ -1,5 +1,6 @@
 package io.divolte.server.kafka;
 
+import static io.divolte.server.processing.ItemProcessor.ProcessingDirective.*;
 import io.divolte.server.AvroRecordBuffer;
 import io.divolte.server.processing.ItemProcessor;
 import kafka.javaapi.producer.Producer;
@@ -34,8 +35,9 @@ final class KafkaFlusher implements ItemProcessor<AvroRecordBuffer> {
     }
 
     @Override
-    public void process(AvroRecordBuffer record) {
+    public ProcessingDirective process(AvroRecordBuffer record) {
         producer.send(buildMessage(record));
+        return CONTINUE;
     }
 
     private KeyedMessage<byte[], byte[]> buildMessage(final AvroRecordBuffer record) {

--- a/src/main/java/io/divolte/server/processing/ItemProcessor.java
+++ b/src/main/java/io/divolte/server/processing/ItemProcessor.java
@@ -1,13 +1,20 @@
 package io.divolte.server.processing;
 
-public interface ItemProcessor<E> {
-    void process(E e);
+import static io.divolte.server.processing.ItemProcessor.ProcessingDirective.*;
 
-    default void heartbeat() {
-        // noop, override to implement heartbeats
+public interface ItemProcessor<E> {
+    ProcessingDirective process(E e);
+
+    default ProcessingDirective heartbeat() {
+        return CONTINUE;
     }
 
     default void cleanup() {
         // noop, override to implement cleanup
+    }
+
+    public enum ProcessingDirective {
+        CONTINUE,
+        PAUSE;
     }
 }


### PR DESCRIPTION
Previously, when HDFS was down, we were still draining the queues and dropping messages. Now, we instruct the processing pool to stop taking items from the queue and just do heartbeats instead. This way, event are only dropped when the queue is full on entry.
