### PR TITLE
Added mapping for all custom event parameters.

### DIFF
--- a/docs/mapping_reference.rst
+++ b/docs/mapping_reference.rst
@@ -670,8 +670,12 @@ eventType
 :Type:
   string
 
-eventParameter
-""""""""""""""
+Complex values
+^^^^^^^^^^^^^^
+Complex values return objects that you can in turn use to extract derived, simple values from. Complex values are either the result of parsing something (e.g. the user agent string) or matching regular expressions against another value.
+
+eventParameters
+"""""""""""""""
 :Usage:
 
   ::
@@ -680,20 +684,51 @@ eventParameter
     divolte.signal('myEvent', { foo: 'hello', bar: 42 });
 
     // in the mapping
-    map eventParameter('foo') onto 'fooField'
+    map eventParameters() onto 'parametersField'
+
+:Description:
+  The value for all parameters that were sent as part of a custom event from JavaScript. Note that these are always strings, regardless of the type used on the client side.
+
+  Use the following Avro type to map the event parameters:
+
+    {
+      "name": "parametersField",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "string"
+          }
+        }
+      ],
+      "default": null
+    }
+
+
+:Type:
+  map<string,string>
+
+eventParameters value
+"""""""""""""""""""""
+:Usage:
+
+  ::
+
+    // on the client in JavaScript:
+    divolte.signal('myEvent', { foo: 'hello', bar: 42 });
+
+    // in the mapping
+    map eventParameters().value('foo') onto 'fooField'
 
     // or with a cast
-    map { parse eventParameter('bar') to int32 } onto 'barField'
+    map { parse eventParameters().value('bar') to int32 } onto 'barField'
 
 :Description:
   The value for a parameter that was sent as part of a custom event from JavaScript. Note that this is always a string, regardless of the type used on the client side. In the case that you are certain a parameter has a specific type, you can explicitly cast it as in the example above.
 
 :Type:
   string
-
-Complex values
-^^^^^^^^^^^^^^
-Complex values return objects that you can in turn use to extract derived, simple values from. Complex values are either the result of parsing something (e.g. the user agent string) or matching regular expressions against another value.
 
 URI
 """

--- a/src/main/java/io/divolte/server/BrowserEventData.java
+++ b/src/main/java/io/divolte/server/BrowserEventData.java
@@ -16,10 +16,13 @@
 
 package io.divolte.server;
 
-import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class BrowserEventData {
@@ -41,6 +44,7 @@ public class BrowserEventData {
     public final Optional<Integer> screenPixelHeight;
     public final Optional<Integer> devicePixelRatio;
     public final Function<String, Optional<String>> eventParameterProducer;
+    public final Supplier<Map<String,String>> eventParametersProducer;
 
     BrowserEventData(final boolean corruptEvent,
                      final CookieValues.CookieValue partyCookie,
@@ -59,24 +63,26 @@ public class BrowserEventData {
                      final Optional<Integer> screenPixelWidth,
                      final Optional<Integer> screenPixelHeight,
                      final Optional<Integer> devicePixelRatio,
-                     final Function<String, Optional<String>> eventParameterProducer) {
-        this.corruptEvent           = corruptEvent;
-        this.partyCookie            = Objects.requireNonNull(partyCookie);
-        this.sessionCookie          = Objects.requireNonNull(sessionCookie);
-        this.pageViewId             = Objects.requireNonNull(pageViewId);
-        this.eventId                = Objects.requireNonNull(eventId);
-        this.requestStartTime       = requestStartTime;
-        this.clientUtcOffset        = clientUtcOffset;
-        this.newPartyId             = newPartyId;
-        this.firstInSession         = firstInSession;
-        this.location               = Objects.requireNonNull(location);
-        this.referer                = Objects.requireNonNull(referer);
-        this.eventType              = Objects.requireNonNull(eventType);
-        this.viewportPixelWidth     = Objects.requireNonNull(viewportPixelWidth);
-        this.viewportPixelHeight    = Objects.requireNonNull(viewportPixelHeight);
-        this.screenPixelWidth       = Objects.requireNonNull(screenPixelWidth);
-        this.screenPixelHeight      = Objects.requireNonNull(screenPixelHeight);
-        this.devicePixelRatio       = Objects.requireNonNull(devicePixelRatio);
-        this.eventParameterProducer = Objects.requireNonNull(eventParameterProducer);
+                     final Function<String, Optional<String>> eventParameterProducer,
+                     Supplier<Map<String,String>> eventParametersProducer) {
+        this.corruptEvent            = corruptEvent;
+        this.partyCookie             = Objects.requireNonNull(partyCookie);
+        this.sessionCookie           = Objects.requireNonNull(sessionCookie);
+        this.pageViewId              = Objects.requireNonNull(pageViewId);
+        this.eventId                 = Objects.requireNonNull(eventId);
+        this.requestStartTime        = requestStartTime;
+        this.clientUtcOffset         = clientUtcOffset;
+        this.newPartyId              = newPartyId;
+        this.firstInSession          = firstInSession;
+        this.location                = Objects.requireNonNull(location);
+        this.referer                 = Objects.requireNonNull(referer);
+        this.eventType               = Objects.requireNonNull(eventType);
+        this.viewportPixelWidth      = Objects.requireNonNull(viewportPixelWidth);
+        this.viewportPixelHeight     = Objects.requireNonNull(viewportPixelHeight);
+        this.screenPixelWidth        = Objects.requireNonNull(screenPixelWidth);
+        this.screenPixelHeight       = Objects.requireNonNull(screenPixelHeight);
+        this.devicePixelRatio        = Objects.requireNonNull(devicePixelRatio);
+        this.eventParameterProducer  = Objects.requireNonNull(eventParameterProducer);
+        this.eventParametersProducer = Objects.requireNonNull(eventParametersProducer);
     }
 }

--- a/src/main/java/io/divolte/server/ClientSideCookieEventHandler.java
+++ b/src/main/java/io/divolte/server/ClientSideCookieEventHandler.java
@@ -17,7 +17,6 @@
 package io.divolte.server;
 
 import static io.divolte.server.IncomingRequestProcessor.*;
-
 import io.divolte.server.CookieValues.CookieValue;
 import io.divolte.server.recordmapping.ConfigRecordMapper;
 import io.undertow.server.HttpServerExchange;
@@ -29,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -122,7 +122,15 @@ public final class ClientSideCookieEventHandler extends BaseEventHandler {
                                     queryParamFromExchange(exchange, SCREEN_PIXEL_WIDTH_QUERY_PARAM).map(ConfigRecordMapper::tryParseBase36Int),
                                     queryParamFromExchange(exchange, SCREEN_PIXEL_HEIGHT_QUERY_PARAM).map(ConfigRecordMapper::tryParseBase36Int),
                                     queryParamFromExchange(exchange, DEVICE_PIXEL_RATIO_QUERY_PARAM).map(ConfigRecordMapper::tryParseBase36Int),
-                                    (name) -> queryParamFromExchange(exchange, EVENT_TYPE_QUERY_PARAM + "." + name));
+                                    (name) -> queryParamFromExchange(exchange, EVENT_TYPE_QUERY_PARAM + "." + name),
+                                    () -> exchange.getQueryParameters()
+                                                  .entrySet()
+                                                  .stream()
+                                                  .filter((e) -> e.getKey().startsWith(EVENT_TYPE_QUERY_PARAM + "."))
+                                                  .collect(Collectors.<Map.Entry<String, Deque<String>>, String, String>toMap(
+                                                          (e) -> e.getKey().substring(2),
+                                                          (e) -> e.getValue().getFirst())
+                                                   ));
     }
 
     static Long tryParseBase36Long(String input) {

--- a/src/main/java/io/divolte/server/recordmapping/DslRecordMapping.java
+++ b/src/main/java/io/divolte/server/recordmapping/DslRecordMapping.java
@@ -562,6 +562,36 @@ public final class DslRecordMapping {
     /*
      * Custom event parameter mapping
      */
+    public final static class EventParameterValueProducer extends ValueProducer<Map<String,String>> {
+        private EventParameterValueProducer() {
+            super("eventParameters()", (h,e,c) -> Optional.of(e.eventParametersProducer.get()));
+        }
+
+        public ValueProducer<String> value(String name) {
+            return new PrimitiveValueProducer<String>(
+                    identifier + ".value(" + name + ")",
+                    String.class,
+                    (h,e,c) -> e.eventParameterProducer.apply(name));
+        }
+
+        @Override
+        boolean validateTypes(Field target) {
+            Optional<Schema> targetSchema = unpackNullableUnion(target.schema());
+            return targetSchema
+                .map((s) -> s.getType() == Type.MAP &&
+                            s.getValueType().getType() == Type.STRING)
+                .orElse(false);
+        }
+    }
+
+    public EventParameterValueProducer eventParameters() {
+        return new EventParameterValueProducer();
+    }
+
+    /*
+     * Remove this at some point. It is not documented, but used in mappings
+     * on some installations.
+     */
     public ValueProducer<String> eventParameter(final String name) {
         return new PrimitiveValueProducer<>("eventParameter(" + name + ")",
                                             String.class,

--- a/src/test/java/io/divolte/server/DslRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/DslRecordMapperTest.java
@@ -74,7 +74,9 @@ public class DslRecordMapperTest {
             + "k=2&"
             + "w=sa&"
             + "h=sa&"
-            + "t=pageView";
+            + "t=pageView&"
+            + "t.foo=string&"
+            + "t.bar=42";
 
     private static final String USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36";
 
@@ -275,6 +277,14 @@ public class DslRecordMapperTest {
         assertEquals(Arrays.asList("first", "second", "last"), event.record.get("headerList"));
         assertEquals("first", event.record.get("header"));
         assertEquals("first,second,last", event.record.get("headers"));
+    }
+
+    @Test
+    public void shouldSetCustomEventParameters() throws IOException, InterruptedException {
+        setupServer("event-param-mapping.groovy");
+        EventPayload event = request("http://www.example.com/");
+        assertEquals(ImmutableMap.of("foo", "string", "bar", "42"), event.record.get("paramMap"));
+        assertEquals("string", event.record.get("paramValue"));
     }
 
     @Test

--- a/src/test/resources/TestRecord.avsc
+++ b/src/test/resources/TestRecord.avsc
@@ -176,7 +176,21 @@
           "default": null
         },
         { "name": "header",                           "type": ["null","string"],  "default": null },
-        { "name": "headers",                           "type": ["null","string"],  "default": null }
+        { "name": "headers",                          "type": ["null","string"],  "default": null },
+	    {
+	      "name": "paramMap",
+	      "type": [
+	        "null",
+	        {
+	          "type": "map",
+	          "values": {
+	            "type": "string"
+	          }
+	        }
+	      ],
+	      "default": null
+	    },
+	    { "name": "paramValue",                       "type": ["null","string"],  "default": null }
 
     ]
 }

--- a/src/test/resources/event-param-mapping.groovy
+++ b/src/test/resources/event-param-mapping.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mapping {
+    map firstInSession() onto 'sessionStart'
+    map timestamp() onto 'ts'
+    map remoteHost() onto 'remoteHost'
+
+    map eventParameters() onto 'paramMap'
+    map eventParameters().value('foo') onto 'paramValue'
+}


### PR DESCRIPTION
Custom events are now modeled after the way URI query params work. There is a complex value producer for mapping all events and a sub-producer for a single event value.

Had to add a extra field to the BrowserEventData to make this work.