### PR TITLE
Renamed config divolte.javascript.debug to divolte.javascript.minify to ...

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -378,7 +378,7 @@ divolte.tracking.javascript.logging
       logging = true
     }
 
-divolte.tracking.javascript.debug
+divolte.tracking.javascript.minify
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :Description:
   When true, the served JavaScript will be compiled, but not minified, improving readability when debugging in the browser.
@@ -389,7 +389,7 @@ divolte.tracking.javascript.debug
   ::
 
     divolte.tracking.javascript {
-      debug = true
+     minify = true
     }
 
 

--- a/src/main/java/io/divolte/server/ValidatedConfiguration.java
+++ b/src/main/java/io/divolte/server/ValidatedConfiguration.java
@@ -116,7 +116,7 @@ public final class ValidatedConfiguration {
         final JavascriptConfiguration javascript = new JavascriptConfiguration(
                 getOrAddException(              config::getString,      "divolte.javascript.name",                      exceptions),
                 getOrAddException(              config::getBoolean,     "divolte.javascript.logging",                   exceptions),
-                getOrAddException(              config::getBoolean,     "divolte.javascript.debug",                     exceptions));
+                getOrAddException(              config::getBoolean,     "divolte.javascript.minify",                     exceptions));
 
         if (javascript.name != null && !javascript.name.matches("^[A-Za-z0-9_-]+\\.js$")) {
             ConfigException.Generic wrongJsNameException = new ConfigException.Generic(

--- a/src/main/java/io/divolte/server/js/TrackingJavaScriptResource.java
+++ b/src/main/java/io/divolte/server/js/TrackingJavaScriptResource.java
@@ -35,7 +35,7 @@ public class TrackingJavaScriptResource extends JavaScriptResource {
     private static final String SCRIPT_CONSTANT_NAME = "SCRIPT_NAME";
 
     public TrackingJavaScriptResource(final ValidatedConfiguration vc) throws IOException {
-        super("divolte.js", createScriptConstants(vc), vc.configuration().javascript.debug);
+        super("divolte.js", createScriptConstants(vc), vc.configuration().javascript.minify);
     }
 
     public String getScriptName() {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -146,7 +146,7 @@ divolte {
 
     // When true, the served JavaScript will be compiled, but not
     // minified, improving readability when debugging in the browser.
-    debug = false
+    minify = false
   }
 
   // This section controls settings related to the processing of incoming


### PR DESCRIPTION
Renamed config flag, for usage clearification.
As javascript.debug doesn't minify the javascript, so the name 'minify = true|false' would be more precice.