### PR TITLE
Fix service shutdown on CentOS 7

### DIFF
--- a/src/scripts/divolte-collector
+++ b/src/scripts/divolte-collector
@@ -87,4 +87,4 @@ JAVACMD="$JAVA_HOME/bin/java"
 [ -f "$CONF_DIR/divolte-collector.conf" ] && JAVA_OPTS="$JAVA_OPTS -Dconfig.file=$CONF_DIR/divolte-collector.conf"
 
 # Replace this launch script with the server process.
-exec $JAVACMD -cp $CLASSPATH $JAVA_OPTS io.divolte.server.Server
+exec $JAVACMD $JAVA_OPTS -cp $CLASSPATH io.divolte.server.Server

--- a/src/scripts/divolte-collector
+++ b/src/scripts/divolte-collector
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2014 GoDataDriven B.V.
+# Copyright 2014-2015 GoDataDriven B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,4 +86,5 @@ JAVACMD="$JAVA_HOME/bin/java"
 [ -f "$CONF_DIR/logback.xml" ] && JAVA_OPTS="$JAVA_OPTS -Dlogback.configurationFile=$CONF_DIR/logback.xml"
 [ -f "$CONF_DIR/divolte-collector.conf" ] && JAVA_OPTS="$JAVA_OPTS -Dconfig.file=$CONF_DIR/divolte-collector.conf"
 
-$JAVACMD -cp $CLASSPATH $JAVA_OPTS io.divolte.server.Server
+# Replace this launch script with the server process.
+exec $JAVACMD -cp $CLASSPATH $JAVA_OPTS io.divolte.server.Server


### PR DESCRIPTION
This pull request updates the wrapper script for running Divolte Collector so that the java process replaces the wrapper script process (via exec). Without this, killing the wrapper script (as the service script does) doesn't always kill the server process itself.

This change should not impact on other platforms; exec'ing the last thing in a shell script is common practice.