### PR TITLE
Updating test mapping server to support specifying a requests remote IP address

### DIFF
--- a/src/main/java/io/divolte/server/MappingTestServer.java
+++ b/src/main/java/io/divolte/server/MappingTestServer.java
@@ -27,6 +27,9 @@ import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -139,6 +142,17 @@ public class MappingTestServer {
                                 Map.Entry::getKey,
                                 (e) -> (String) e.getValue())),
                 Optional.of(browserEventData));
+
+        get(payload, "remote_host", String.class)
+            .ifPresent(ip -> {
+                try {
+                    final InetAddress address = InetAddress.getByName(ip);
+                    //we have no way of knowing the port
+                    exchange.setSourceAddress(new InetSocketAddress(address, 0));
+                } catch (final UnknownHostException e) {
+                    log.warn("Could not parse remote host: " + ip, e);
+                }
+            });
 
         exchange.putAttachment(DIVOLTE_EVENT_KEY, divolteEvent);
         exchange.putAttachment(DUPLICATE_EVENT_KEY, get(payload, "duplicate", Boolean.class).orElse(false));

--- a/src/main/java/io/divolte/server/MappingTestServer.java
+++ b/src/main/java/io/divolte/server/MappingTestServer.java
@@ -74,9 +74,10 @@ public class MappingTestServer {
         mapper = new DslRecordMapper(vc, mappingFilename, schema, Optional.ofNullable(lookupServiceFromConfig(vc)));
 
         final HttpHandler handler = new AllowedMethodsHandler(this::handleEvent, Methods.POST);
+        final HttpHandler rootHandler = new ProxyAdjacentPeerAddressHandler(handler);
         undertow = Undertow.builder()
                 .addHttpListener(port, host)
-                .setHandler(handler)
+                .setHandler(rootHandler)
                 .build();
     }
 


### PR DESCRIPTION
The test mapping server is experimental, and undocumented. However it is useful for testing mappings. At present the remoteHost() field always comes from the client IP address, which makes testing GeoIP stuff difficult when you're on a private network, or even localhost.

This pull request updates the test mapping server to check mapping requests for:

1. a `remote_host` member in the request payload.
2. a `x-forwarded-for` header;

The first of these present, if any, will be used as the `remoteHost()` value instead of the client's actual IP address.