### PR TITLE
Dev/event container

### DIFF
--- a/src/main/java/io/divolte/server/DivolteEvent.java
+++ b/src/main/java/io/divolte/server/DivolteEvent.java
@@ -19,6 +19,8 @@ package io.divolte.server;
 import javax.annotation.ParametersAreNonnullByDefault;
 import com.fasterxml.jackson.databind.JsonNode;
 
+import io.undertow.server.HttpServerExchange;
+
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -31,6 +33,8 @@ import java.util.function.Supplier;
  */
 @ParametersAreNonnullByDefault
 public final class DivolteEvent {
+    public final HttpServerExchange exchange;
+
     // Events from all sources support these attributes.
     public final boolean corruptEvent;
     public final DivolteIdentifier partyCookie;
@@ -79,7 +83,8 @@ public final class DivolteEvent {
         }
     }
 
-    DivolteEvent(final boolean corruptEvent,
+    DivolteEvent(final HttpServerExchange originatingExchange,
+                 final boolean corruptEvent,
                  final DivolteIdentifier partyCookie,
                  final DivolteIdentifier sessionCookie,
                  final String eventId,
@@ -91,6 +96,7 @@ public final class DivolteEvent {
                  final Optional<String> eventType,
                  final Supplier<Optional<JsonNode>> eventParametersProducer,
                  final Optional<BrowserEventData> browserEvent) {
+        this.exchange = originatingExchange;
         this.corruptEvent            = corruptEvent;
         this.partyCookie             = Objects.requireNonNull(partyCookie);
         this.sessionCookie           = Objects.requireNonNull(sessionCookie);

--- a/src/main/java/io/divolte/server/DivolteEvent.java
+++ b/src/main/java/io/divolte/server/DivolteEvent.java
@@ -96,7 +96,7 @@ public final class DivolteEvent {
                  final Optional<String> eventType,
                  final Supplier<Optional<JsonNode>> eventParametersProducer,
                  final Optional<BrowserEventData> browserEvent) {
-        this.exchange = originatingExchange;
+        this.exchange                = originatingExchange;
         this.corruptEvent            = corruptEvent;
         this.partyCookie             = Objects.requireNonNull(partyCookie);
         this.sessionCookie           = Objects.requireNonNull(sessionCookie);

--- a/src/main/java/io/divolte/server/IncomingRequestListener.java
+++ b/src/main/java/io/divolte/server/IncomingRequestListener.java
@@ -18,8 +18,6 @@ package io.divolte.server;
 
 import org.apache.avro.generic.GenericRecord;
 
-import io.undertow.server.HttpServerExchange;
-
 interface IncomingRequestListener {
-    void incomingRequest(HttpServerExchange exchange, AvroRecordBuffer avroBuffer, GenericRecord avroRecord);
+    void incomingRequest(DivolteEvent event, AvroRecordBuffer avroBuffer, GenericRecord avroRecord);
 }

--- a/src/main/java/io/divolte/server/IncomingRequestProcessor.java
+++ b/src/main/java/io/divolte/server/IncomingRequestProcessor.java
@@ -157,14 +157,14 @@ public final class IncomingRequestProcessor implements ItemProcessor<DivolteEven
                         event.clientUtcOffset,
                         avroRecord);
                 listener.incomingRequest(event, avroBuffer, avroRecord);
-                doProcess(avroRecord, avroBuffer);
+                doProcess(avroBuffer);
             }
         }
 
         return CONTINUE;
     }
 
-    private void doProcess(final GenericRecord avroRecord, final AvroRecordBuffer avroBuffer) {
+    private void doProcess(final AvroRecordBuffer avroBuffer) {
 
         if (null != kafkaFlushingPool) {
             kafkaFlushingPool.enqueue(avroBuffer.getPartyId().value, avroBuffer);

--- a/src/main/java/io/divolte/server/IncomingRequestProcessor.java
+++ b/src/main/java/io/divolte/server/IncomingRequestProcessor.java
@@ -48,7 +48,6 @@ import io.undertow.util.AttachmentKey;
 public final class IncomingRequestProcessor implements ItemProcessor<DivolteEvent> {
     private static final Logger logger = LoggerFactory.getLogger(IncomingRequestProcessor.class);
 
-    public static final AttachmentKey<DivolteEvent> DIVOLTE_EVENT_KEY = AttachmentKey.create(DivolteEvent.class);
     public static final AttachmentKey<Boolean> DUPLICATE_EVENT_KEY = AttachmentKey.create(Boolean.class);
 
     @Nullable

--- a/src/main/java/io/divolte/server/IncomingRequestProcessor.java
+++ b/src/main/java/io/divolte/server/IncomingRequestProcessor.java
@@ -17,6 +17,18 @@
 package io.divolte.server;
 
 import static io.divolte.server.processing.ItemProcessor.ProcessingDirective.*;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.divolte.record.DefaultEventRecord;
 import io.divolte.server.config.ValidatedConfiguration;
 import io.divolte.server.hdfs.HdfsFlusher;
@@ -30,22 +42,10 @@ import io.divolte.server.recordmapping.DslRecordMapper;
 import io.divolte.server.recordmapping.DslRecordMapping;
 import io.divolte.server.recordmapping.RecordMapper;
 import io.divolte.server.recordmapping.UserAgentParserAndCache;
-import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
 
-import java.util.Objects;
-import java.util.Optional;
-
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 @ParametersAreNonnullByDefault
-public final class IncomingRequestProcessor implements ItemProcessor<HttpServerExchange> {
+public final class IncomingRequestProcessor implements ItemProcessor<DivolteEvent> {
     private static final Logger logger = LoggerFactory.getLogger(IncomingRequestProcessor.class);
 
     public static final AttachmentKey<DivolteEvent> DIVOLTE_EVENT_KEY = AttachmentKey.create(DivolteEvent.class);
@@ -137,14 +137,8 @@ public final class IncomingRequestProcessor implements ItemProcessor<HttpServerE
     }
 
     @Override
-    public ProcessingDirective process(final HttpServerExchange exchange) {
-        final DivolteEvent eventData = exchange.getAttachment(DIVOLTE_EVENT_KEY);
-
-        if (!eventData.corruptEvent || keepCorrupted) {
-            final DivolteIdentifier party = eventData.partyCookie;
-            final DivolteIdentifier session = eventData.sessionCookie;
-            final String event = eventData.eventId;
-
+    public ProcessingDirective process(final DivolteEvent event) {
+        if (!event.corruptEvent || keepCorrupted) {
             /*
              * Note: we cannot use the actual query string here,
              * as the incoming request processor is agnostic of
@@ -152,26 +146,26 @@ public final class IncomingRequestProcessor implements ItemProcessor<HttpServerE
              * an endpoint that doesn't require a query string,
              * but rather generates these IDs on the server side.
              */
-            final boolean duplicate = memory.isProbableDuplicate(party.value, session.value, event);
-            exchange.putAttachment(DUPLICATE_EVENT_KEY, duplicate);
+            final boolean duplicate = memory.isProbableDuplicate(event.partyCookie.value, event.sessionCookie.value, event.eventId);
+            event.exchange.putAttachment(DUPLICATE_EVENT_KEY, duplicate);
 
             if (!duplicate || keepDuplicates) {
-                final GenericRecord avroRecord = mapper.newRecordFromExchange(exchange);
+                final GenericRecord avroRecord = mapper.newRecordFromExchange(event);
                 final AvroRecordBuffer avroBuffer = AvroRecordBuffer.fromRecord(
-                        party,
-                        session,
-                        eventData.requestStartTime,
-                        eventData.clientUtcOffset,
+                        event.partyCookie,
+                        event.sessionCookie,
+                        event.requestStartTime,
+                        event.clientUtcOffset,
                         avroRecord);
-                doProcess(exchange, avroRecord, avroBuffer);
+                listener.incomingRequest(event, avroBuffer, avroRecord);
+                doProcess(avroRecord, avroBuffer);
             }
         }
 
         return CONTINUE;
     }
 
-    private void doProcess(final HttpServerExchange exchange, final GenericRecord avroRecord, final AvroRecordBuffer avroBuffer) {
-        listener.incomingRequest(exchange, avroBuffer, avroRecord);
+    private void doProcess(final GenericRecord avroRecord, final AvroRecordBuffer avroBuffer) {
 
         if (null != kafkaFlushingPool) {
             kafkaFlushingPool.enqueue(avroBuffer.getPartyId().value, avroBuffer);

--- a/src/main/java/io/divolte/server/MappingTestServer.java
+++ b/src/main/java/io/divolte/server/MappingTestServer.java
@@ -152,7 +152,6 @@ public class MappingTestServer {
                     }
                 });
 
-            exchange.putAttachment(DIVOLTE_EVENT_KEY, divolteEvent);
             exchange.putAttachment(DUPLICATE_EVENT_KEY, get(payload, "duplicate", Boolean.class).orElse(false));
 
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");

--- a/src/main/java/io/divolte/server/MappingTestServer.java
+++ b/src/main/java/io/divolte/server/MappingTestServer.java
@@ -127,6 +127,7 @@ public class MappingTestServer {
                     get(payload, "screen_pixel_height", Integer.class),
                     get(payload, "device_pixel_ratio", Integer.class));
             final DivolteEvent divolteEvent = new DivolteEvent(
+                    exchange,
                     get(payload, "corrupt", Boolean.class).orElse(false),
                     get(payload, "party_id", String.class).flatMap(DivolteIdentifier::tryParse).orElse(DivolteIdentifier.generate()),
                     get(payload, "session_id", String.class).flatMap(DivolteIdentifier::tryParse).orElse(DivolteIdentifier.generate()),
@@ -155,7 +156,7 @@ public class MappingTestServer {
             exchange.putAttachment(DUPLICATE_EVENT_KEY, get(payload, "duplicate", Boolean.class).orElse(false));
 
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
-            exchange.getResponseChannel().write(ByteBuffer.wrap(mapper.newRecordFromExchange(exchange).toString().getBytes(StandardCharsets.UTF_8)));
+            exchange.getResponseChannel().write(ByteBuffer.wrap(mapper.newRecordFromExchange(divolteEvent).toString().getBytes(StandardCharsets.UTF_8)));
             exchange.endExchange();
         }
     }

--- a/src/main/java/io/divolte/server/recordmapping/DslRecordMapper.java
+++ b/src/main/java/io/divolte/server/recordmapping/DslRecordMapper.java
@@ -16,17 +16,6 @@
 
 package io.divolte.server.recordmapping;
 
-import static io.divolte.server.IncomingRequestProcessor.*;
-import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
-import groovy.lang.Script;
-import io.divolte.server.DivolteEvent;
-import io.divolte.server.config.ValidatedConfiguration;
-import io.divolte.server.ip2geo.LookupService;
-import io.divolte.server.recordmapping.DslRecordMapping.MappingAction;
-import io.divolte.server.recordmapping.DslRecordMapping.MappingAction.MappingResult;
-import io.undertow.server.HttpServerExchange;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -48,6 +37,15 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import groovy.lang.Script;
+import io.divolte.server.DivolteEvent;
+import io.divolte.server.config.ValidatedConfiguration;
+import io.divolte.server.ip2geo.LookupService;
+import io.divolte.server.recordmapping.DslRecordMapping.MappingAction;
+import io.divolte.server.recordmapping.DslRecordMapping.MappingAction.MappingResult;
 
 @ParametersAreNonnullByDefault
 @NotThreadSafe
@@ -83,7 +81,7 @@ public class DslRecordMapper implements RecordMapper {
             script.run();
 
             actions = mapping.actions();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new RuntimeException("Could not load mapping script file: " + groovyFile, e);
         }
     }
@@ -94,13 +92,12 @@ public class DslRecordMapper implements RecordMapper {
     }
 
     @Override
-    public GenericRecord newRecordFromExchange(HttpServerExchange exchange) {
+    public GenericRecord newRecordFromExchange(final DivolteEvent event) {
         final GenericRecordBuilder builder = new GenericRecordBuilder(schema);
-        final DivolteEvent eventData = exchange.getAttachment(DIVOLTE_EVENT_KEY);
         final Map<String,Optional<?>> context = Maps.newHashMapWithExpectedSize(20);
 
         for (final Iterator<MappingAction> itr = actions.iterator();
-             itr.hasNext() && itr.next().perform(exchange, eventData, context, builder) == MappingResult.CONTINUE;) {
+             itr.hasNext() && itr.next().perform(event, context, builder) == MappingResult.CONTINUE;) {
             // Nothing needed in here.
         }
 

--- a/src/main/java/io/divolte/server/recordmapping/RecordMapper.java
+++ b/src/main/java/io/divolte/server/recordmapping/RecordMapper.java
@@ -16,10 +16,10 @@
 
 package io.divolte.server.recordmapping;
 
-import io.undertow.server.HttpServerExchange;
-
 import org.apache.avro.generic.GenericRecord;
 
+import io.divolte.server.DivolteEvent;
+
 public interface RecordMapper {
-    GenericRecord newRecordFromExchange(final HttpServerExchange exchange);
+    GenericRecord newRecordFromExchange(final DivolteEvent event);
 }

--- a/src/test/java/io/divolte/server/DslRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/DslRecordMapperTest.java
@@ -17,7 +17,6 @@
 package io.divolte.server;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;

--- a/src/test/java/io/divolte/server/DslRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/DslRecordMapperTest.java
@@ -16,6 +16,35 @@
 
 package io.divolte.server;
 
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
+import org.junit.After;
+import org.junit.Test;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.InjectableValues;
@@ -34,33 +63,6 @@ import io.divolte.server.ip2geo.LookupService;
 import io.divolte.server.ip2geo.LookupService.ClosedServiceException;
 import io.divolte.server.recordmapping.DslRecordMapper;
 import io.divolte.server.recordmapping.SchemaMappingException;
-import io.undertow.server.HttpServerExchange;
-
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.util.Utf8;
-import org.junit.After;
-import org.junit.Test;
-
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.*;
-import java.util.stream.Stream;
-
-import static io.divolte.server.IncomingRequestProcessor.DIVOLTE_EVENT_KEY;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
 
 @ParametersAreNonnullByDefault
 public class DslRecordMapperTest {
@@ -99,15 +101,14 @@ public class DslRecordMapperTest {
     public void shouldPopulateFlatFields() throws InterruptedException, IOException {
         setupServer("flat-mapping.groovy");
 
-        EventPayload event = request("https://example.com/", "http://example.com/");
-        final GenericRecord record = event.record;
-        final HttpServerExchange exchange = event.exchange;
-        final DivolteEvent eventData = exchange.getAttachment(DIVOLTE_EVENT_KEY);
+        final EventPayload payload = request("https://example.com/", "http://example.com/");
+        final GenericRecord record = payload.record;
+        final DivolteEvent event = payload.event;
 
         assertEquals(true, record.get("sessionStart"));
         assertEquals(true, record.get("unreliable"));
         assertEquals(false, record.get("dupe"));
-        assertEquals(eventData.requestStartTime, record.get("ts"));
+        assertEquals(event.requestStartTime, record.get("ts"));
         assertEquals("https://example.com/", record.get("location"));
         assertEquals("http://example.com/", record.get("referer"));
 
@@ -122,10 +123,10 @@ public class DslRecordMapperTest {
         assertEquals("10.10.1", record.get("userAgentOsVersion"));
         assertEquals("Apple Computer, Inc.", record.get("userAgentOsVendor"));
 
-        assertEquals(eventData.partyCookie.value, record.get("client"));
-        assertEquals(eventData.sessionCookie.value, record.get("session"));
-        assertEquals(eventData.browserEventData.get().pageViewId, record.get("pageview"));
-        assertEquals(eventData.eventId, record.get("event"));
+        assertEquals(event.partyCookie.value, record.get("client"));
+        assertEquals(event.sessionCookie.value, record.get("session"));
+        assertEquals(event.browserEventData.get().pageViewId, record.get("pageview"));
+        assertEquals(event.eventId, record.get("event"));
         assertEquals(1018, record.get("viewportWidth"));
         assertEquals(1018, record.get("viewportHeight"));
         assertEquals(1024, record.get("screenWidth"));
@@ -181,14 +182,14 @@ public class DslRecordMapperTest {
     @Test
     public void shouldSetCustomCookieValue() throws InterruptedException, IOException {
         setupServer("custom-cookie-mapping.groovy");
-        EventPayload event = request("http://example.com");
+        final EventPayload event = request("http://example.com");
         assertEquals("custom_cookie_value", event.record.get("customCookie"));
     }
 
     @Test
     public void shouldApplyActionsInClosureWhenEqualToConditionHolds() throws IOException, InterruptedException {
         setupServer("when-mapping.groovy");
-        EventPayload event = request("http://www.example.com/", "http://www.example.com/somepage.html");
+        final EventPayload event = request("http://www.example.com/", "http://www.example.com/somepage.html");
 
         assertEquals("locationmatch", event.record.get("eventType"));
         assertEquals("referermatch", event.record.get("client"));
@@ -201,14 +202,14 @@ public class DslRecordMapperTest {
     @Test
     public void shouldChainValueProducersWithIntermediateNull() throws IOException, InterruptedException {
         setupServer("chained-na-mapping.groovy");
-        EventPayload event = request("http://www.exmaple.com/");
+        final EventPayload event = request("http://www.exmaple.com/");
         assertEquals(new Utf8("not set"), event.record.get("queryparam"));
     }
 
     @Test
     public void shouldMatchRegexAndExtractGroups() throws IOException, InterruptedException {
         setupServer("regex-mapping.groovy");
-        EventPayload event = request("http://www.example.com/path/with/42/about.html", "http://www.example.com/path/with/13/contact.html");
+        final EventPayload event = request("http://www.example.com/path/with/42/about.html", "http://www.example.com/path/with/13/contact.html");
         assertEquals(true, event.record.get("pathBoolean"));
         assertEquals("42", event.record.get("client"));
         assertEquals("about", event.record.get("pageview"));
@@ -217,7 +218,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldParseUriComponents() throws IOException, InterruptedException {
         setupServer("uri-mapping.groovy");
-        EventPayload event = request(
+        final EventPayload event = request(
                 "https://www.example.com:8080/path/to/resource/page.html?q=multiple+words+%24%23%25%26&p=10&p=20",
                 "http://example.com/path/to/resource/page.html?q=divolte&p=42#/client/side/path?x=value&y=42");
 
@@ -239,7 +240,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldParseUriComponentsRaw() throws IOException, InterruptedException {
         setupServer("uri-mapping-raw.groovy");
-        EventPayload event = request(
+        final EventPayload event = request(
                 "http://example.com/path/to/resource%20and%20such/page.html?q=multiple+words+%24%23%25%26&p=42#/client/side/path?x=value&y=42&q=multiple+words+%24%23%25%26");
         assertEquals("/path/to/resource%20and%20such/page.html", event.record.get("uriPath"));
         assertEquals("q=multiple+words+%24%23%25%26&p=42", event.record.get("uriQueryString"));
@@ -256,7 +257,7 @@ public class DslRecordMapperTest {
          * it.
          */
         setupServer("uri-mapping-fragment.groovy");
-        EventPayload event = request(
+        final EventPayload event = request(
                 "http://example.com/path/?q=divolte#/client/side/path?x=value&y=42&q=multiple+words+%24%23%25%26");
         assertEquals("/client/side/path", event.record.get("uriPath"));
         assertEquals("x=value&y=42&q=multiple+words+%24%23%25%26", event.record.get("uriQueryString"));
@@ -266,7 +267,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldNotFailOnBrokenQueryString() throws IOException, InterruptedException {
         setupServer("funky-querystring-mapping.groovy");
-        EventPayload event = request("http://example.com/path/?a=value&=42&b=&d=word&c&=bla");
+        final EventPayload event = request("http://example.com/path/?a=value&=42&b=&d=word&c&=bla");
 
         /*
          * Query string parsing semantics:
@@ -284,7 +285,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldSetCustomHeaders() throws IOException, InterruptedException {
         setupServer("header-mapping.groovy");
-        EventPayload event = request("http://www.example.com/");
+        final EventPayload event = request("http://www.example.com/");
         assertEquals(Arrays.asList("first", "second", "last"), event.record.get("headerList"));
         assertEquals("first", event.record.get("header"));
         assertEquals("first,second,last", event.record.get("headers"));
@@ -293,7 +294,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldSetCustomEventParameters() throws IOException, InterruptedException {
         setupServer("event-param-mapping.groovy");
-        EventPayload event = request("http://www.example.com/", Collections.singletonList(HOMOGENOUS_EVENT_PARAMS));
+        final EventPayload event = request("http://www.example.com/", Collections.singletonList(HOMOGENOUS_EVENT_PARAMS));
         assertEquals(ImmutableMap.of("foo", "string", "bar", "42"), event.record.get("paramMap"));
         assertEquals("string", event.record.get("paramValue"));
     }
@@ -355,7 +356,7 @@ public class DslRecordMapperTest {
          * instance to test the ip2geo mapping (using the a mock lookup service).
          */
         setupServer("minimal-mapping.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload payload = request("http://www.example.com");
 
         final File geoMappingFile = File.createTempFile("geo-mapping", ".groovy");
         copyResourceToFile("geo-mapping.groovy", geoMappingFile);
@@ -381,7 +382,7 @@ public class DslRecordMapperTest {
                 new Schema.Parser().parse(Resources.toString(Resources.getResource("TestRecord.avsc"), StandardCharsets.UTF_8)),
                 Optional.of(mockLookupService));
 
-        final GenericRecord record = mapper.newRecordFromExchange(event.exchange);
+        final GenericRecord record = mapper.newRecordFromExchange(payload.event);
 
         // Validate the results.
         verify(mockLookupService).lookup(any());
@@ -409,7 +410,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldMapLiteralsOntoCorrectTypes() throws IOException, InterruptedException {
         setupServer("correct-types-literal.groovy");
-        EventPayload event = request("http://www.example.com/correct");
+        final EventPayload event = request("http://www.example.com/correct");
         assertEquals("string value", event.record.get("queryparam"));
         assertEquals(true, event.record.get("queryparamBoolean"));
         assertEquals(42L, event.record.get("queryparamLong"));
@@ -420,7 +421,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldStopWhenToldTo() throws IOException, InterruptedException {
         setupServer("basic-stop.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertNull(event.record.get("session"));
     }
@@ -428,7 +429,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldStopOnNestedStop() throws IOException, InterruptedException {
         setupServer("nested-conditional-stop.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertNull(event.record.get("session"));
     }
@@ -436,7 +437,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldStopOnCondition() throws IOException, InterruptedException {
         setupServer("shorthand-conditional-stop.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertNull(event.record.get("session"));
     }
@@ -444,7 +445,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldStopOnConditionClosureSyntax() throws IOException, InterruptedException {
         setupServer("shorthand-conditional-stop-closure.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertNull(event.record.get("session"));
     }
@@ -452,7 +453,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldStopOnTopLevelExit() throws IOException, InterruptedException {
         setupServer("basic-toplevel-exit.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertNull(event.record.get("session"));
     }
@@ -460,7 +461,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldExitFromSectionOnCondition() throws IOException, InterruptedException {
         setupServer("nested-conditional-exit.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertEquals("happened", event.record.get("pageview"));
         assertEquals("happened", event.record.get("event"));
@@ -471,7 +472,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldExitFromSectionOnConditionClosureSyntax() throws IOException, InterruptedException {
         setupServer("nested-conditional-exit-closure.groovy");
-        EventPayload event = request("http://www.example.com");
+        final EventPayload event = request("http://www.example.com");
         assertEquals("happened", event.record.get("client"));
         assertEquals("happened", event.record.get("pageview"));
         assertEquals("happened", event.record.get("event"));
@@ -482,7 +483,7 @@ public class DslRecordMapperTest {
     @Test
     public void shouldApplyBooleanLogic() throws IOException, InterruptedException {
         setupServer("boolean-logic.groovy");
-        EventPayload event = request("http://www.example.com/");
+        final EventPayload event = request("http://www.example.com/");
         assertTrue((Boolean) event.record.get("unreliable"));
         assertFalse((Boolean) event.record.get("dupe"));
         assertTrue((Boolean) event.record.get("queryparamBoolean"));
@@ -544,7 +545,7 @@ public class DslRecordMapperTest {
         avroFile = File.createTempFile("TestSchema-", ".avsc");
         copyResourceToFile("TestRecord.avsc", avroFile);
 
-        ImmutableMap<String, Object> mappingConfig = ImmutableMap.of(
+        final ImmutableMap<String, Object> mappingConfig = ImmutableMap.of(
                 "divolte.tracking.schema_mapping.mapping_script_file", mappingFile.getAbsolutePath(),
                 "divolte.tracking.schema_file", avroFile.getAbsolutePath()
                 );

--- a/src/test/java/io/divolte/server/ProxyAdjacentPeerAddressHandlerTest.java
+++ b/src/test/java/io/divolte/server/ProxyAdjacentPeerAddressHandlerTest.java
@@ -52,54 +52,54 @@ public class ProxyAdjacentPeerAddressHandlerTest {
     @Test
     public void shouldObtainRightMostAddressFromChain() throws IOException, InterruptedException {
         final URL url = new URL(String.format(URL_STRING, server.port) + URL_QUERY_STRING);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.addRequestProperty("X-Forwarded-For", "127.0.0.1,192.168.13.23");
         conn.setRequestMethod("GET");
 
         assertEquals(200, conn.getResponseCode());
 
-        EventPayload event = server.waitForEvent();
-        assertEquals("192.168.13.23", event.exchange.getSourceAddress().getHostString());
+        final EventPayload payload = server.waitForEvent();
+        assertEquals("192.168.13.23", payload.event.exchange.getSourceAddress().getHostString());
     }
 
     @Test
     public void shouldObtainSingleValueWithoutCommas() throws IOException, InterruptedException {
         final URL url = new URL(String.format(URL_STRING, server.port) + URL_QUERY_STRING);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.addRequestProperty("X-Forwarded-For", "127.0.0.1");
         conn.setRequestMethod("GET");
 
         assertEquals(200, conn.getResponseCode());
 
-        EventPayload event = server.waitForEvent();
-        assertEquals("127.0.0.1", event.exchange.getSourceAddress().getHostString());
+        final EventPayload payload = server.waitForEvent();
+        assertEquals("127.0.0.1", payload.event.exchange.getSourceAddress().getHostString());
     }
 
     @Test
     public void shouldAllowWhitespaceAfterComma() throws IOException, InterruptedException {
         final URL url = new URL(String.format(URL_STRING, server.port) + URL_QUERY_STRING);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.addRequestProperty("X-Forwarded-For", "127.0.0.1, 192.168.13.23");
         conn.setRequestMethod("GET");
 
         assertEquals(200, conn.getResponseCode());
 
-        EventPayload event = server.waitForEvent();
-        assertEquals("192.168.13.23", event.exchange.getSourceAddress().getHostString());
+        final EventPayload payload = server.waitForEvent();
+        assertEquals("192.168.13.23", payload.event.exchange.getSourceAddress().getHostString());
     }
 
     @Test
     public void shouldAllowMultipleXffHeaders() throws IOException, InterruptedException {
         final URL url = new URL(String.format(URL_STRING, server.port) + URL_QUERY_STRING);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.addRequestProperty("X-Forwarded-For", "127.0.0.1, 8.8.8.8");
         conn.addRequestProperty("X-Forwarded-For", "192.168.13.23");
         conn.setRequestMethod("GET");
 
         assertEquals(200, conn.getResponseCode());
 
-        EventPayload event = server.waitForEvent();
-        assertEquals("192.168.13.23", event.exchange.getSourceAddress().getHostString());
+        final EventPayload payload = server.waitForEvent();
+        assertEquals("192.168.13.23", payload.event.exchange.getSourceAddress().getHostString());
     }
 
     @Before

--- a/src/test/java/io/divolte/server/RequestChecksumTest.java
+++ b/src/test/java/io/divolte/server/RequestChecksumTest.java
@@ -16,23 +16,23 @@
 
 package io.divolte.server;
 
-import com.google.common.base.Preconditions;
-import io.divolte.server.ServerTestUtils.EventPayload;
-import io.divolte.server.ServerTestUtils.TestServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static io.divolte.server.IncomingRequestProcessor.DIVOLTE_EVENT_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Preconditions;
+
+import io.divolte.server.ServerTestUtils.EventPayload;
+import io.divolte.server.ServerTestUtils.TestServer;
 
 @ParametersAreNonnullByDefault
 public class RequestChecksumTest {
@@ -102,24 +102,24 @@ public class RequestChecksumTest {
     public void shouldFlagCorrectChecksumAsNotCorrupted() throws IOException, InterruptedException {
         request(URL_QUERY_CHECKSUM_GOOD);
         Preconditions.checkState(null != server);
-        final EventPayload event = server.waitForEvent();
-        assertFalse(event.exchange.getAttachment(DIVOLTE_EVENT_KEY).corruptEvent);
+        final EventPayload payload = server.waitForEvent();
+        assertFalse(payload.event.corruptEvent);
     }
 
     @Test
     public void shouldFlagIncorrectChecksumAsCorrupted() throws IOException, InterruptedException {
         request(URL_QUERY_CHECKSUM_BAD);
         Preconditions.checkState(null != server);
-        final EventPayload event = server.waitForEvent();
-        assertTrue(event.exchange.getAttachment(DIVOLTE_EVENT_KEY).corruptEvent);
+        final EventPayload payload = server.waitForEvent();
+        assertTrue(payload.event.corruptEvent);
     }
 
     @Test
     public void shouldFlagMissingChecksumAsCorrupted() throws IOException, InterruptedException {
         request(URL_QUERY_CHECKSUM_MISSING);
         Preconditions.checkState(null != server);
-        final EventPayload event = server.waitForEvent();
-        assertTrue(event.exchange.getAttachment(DIVOLTE_EVENT_KEY).corruptEvent);
+        final EventPayload payload = server.waitForEvent();
+        assertTrue(payload.event.corruptEvent);
     }
 
     @Test
@@ -127,8 +127,8 @@ public class RequestChecksumTest {
         for (final String urlQueryChecksumPartial : URL_QUERY_CHECKSUM_PARTIALS) {
             request(urlQueryChecksumPartial);
             Preconditions.checkState(null != server);
-            final EventPayload event = server.waitForEvent();
-            assertTrue(event.exchange.getAttachment(DIVOLTE_EVENT_KEY).corruptEvent);
+            final EventPayload payload = server.waitForEvent();
+            assertTrue(payload.event.corruptEvent);
         }
     }
 
@@ -136,8 +136,8 @@ public class RequestChecksumTest {
     public void shouldChecksumCorrectlyWithNonAsciiParameters() throws IOException, InterruptedException {
         request(URL_QUERY_CHECKSUM_UNICODE);
         Preconditions.checkState(null != server);
-        final EventPayload event = server.waitForEvent();
-        final DivolteEvent eventData = event.exchange.getAttachment(DIVOLTE_EVENT_KEY);
+        final EventPayload payload = server.waitForEvent();
+        final DivolteEvent eventData = payload.event;
         assertFalse(eventData.corruptEvent);
         assertEquals("ụñ⚕©ºḌℨ", eventData.eventType.get());
     }
@@ -148,9 +148,9 @@ public class RequestChecksumTest {
         request(URL_QUERY_CHECKSUM_BAD);
         request(URL_QUERY_SENTINEL);
         Preconditions.checkState(null != server);
-        final EventPayload event = server.waitForEvent();
+        final EventPayload payload = server.waitForEvent();
         // The first request should be missing, and we should now have the sentinel event.
-        final String eventType = event.exchange.getAttachment(DIVOLTE_EVENT_KEY).eventType.get();
+        final String eventType = payload.event.eventType.get();
         assertEquals("sentinelEvent", eventType);
     }
 
@@ -178,7 +178,7 @@ public class RequestChecksumTest {
         setServer(null);
     }
 
-    private void setServer(@Nullable TestServer newServer) {
+    private void setServer(@Nullable final TestServer newServer) {
         final TestServer oldServer = this.server;
         if (oldServer != newServer) {
             if (null != oldServer) {

--- a/src/test/java/io/divolte/server/SeleniumDisabledAutoPageViewEventTest.java
+++ b/src/test/java/io/divolte/server/SeleniumDisabledAutoPageViewEventTest.java
@@ -1,16 +1,18 @@
 package io.divolte.server;
 
-import com.google.common.base.Preconditions;
-import io.divolte.server.ServerTestUtils.EventPayload;
+import static io.divolte.server.SeleniumTestBase.TEST_PAGES.*;
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Optional;
+import com.google.common.base.Preconditions;
 
-import static io.divolte.server.IncomingRequestProcessor.DIVOLTE_EVENT_KEY;
-import static io.divolte.server.SeleniumTestBase.TEST_PAGES.CUSTOM_PAGE_VIEW;
-import static org.junit.Assert.*;
+import io.divolte.server.ServerTestUtils.EventPayload;
 
 @ParametersAreNonnullByDefault
 public class SeleniumDisabledAutoPageViewEventTest extends SeleniumTestBase {
@@ -26,9 +28,9 @@ public class SeleniumDisabledAutoPageViewEventTest extends SeleniumTestBase {
         final String location = urlOf(CUSTOM_PAGE_VIEW);
         driver.get(location);
 
-        EventPayload viewEvent = server.waitForEvent();
+        final EventPayload payload = server.waitForEvent();
 
-        final DivolteEvent eventData = viewEvent.exchange.getAttachment(DIVOLTE_EVENT_KEY);
+        final DivolteEvent eventData = payload.event;
         final Optional<String> eventParameters = eventData.eventParametersProducer.get().map(Object::toString);
         assertTrue(eventParameters.isPresent());
         assertEquals("{\"foo\":\"moo\",\"bar\":\"baz\"}", eventParameters.get());

--- a/src/test/java/io/divolte/server/ServerTestUtils.java
+++ b/src/test/java/io/divolte/server/ServerTestUtils.java
@@ -16,9 +16,6 @@
 
 package io.divolte.server;
 
-import io.divolte.server.config.ValidatedConfiguration;
-import io.undertow.server.HttpServerExchange;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.Map;
@@ -35,6 +32,8 @@ import org.apache.avro.generic.GenericRecord;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValueFactory;
+
+import io.divolte.server.config.ValidatedConfiguration;
 
 public final class ServerTestUtils {
     /*
@@ -53,14 +52,14 @@ public final class ServerTestUtils {
 
     @ParametersAreNonnullByDefault
     public static final class EventPayload {
-        final HttpServerExchange exchange;
+        final DivolteEvent event;
         final AvroRecordBuffer buffer;
         final GenericRecord record;
 
-        public EventPayload(final HttpServerExchange exchange,
+        public EventPayload(final DivolteEvent event,
                              final AvroRecordBuffer buffer,
                              final GenericRecord record) {
-            this.exchange = Objects.requireNonNull(exchange);
+            this.event = Objects.requireNonNull(event);
             this.buffer = Objects.requireNonNull(buffer);
             this.record = Objects.requireNonNull(record);
         }
@@ -96,7 +95,7 @@ public final class ServerTestUtils {
 
             events = new ArrayBlockingQueue<>(100);
             final ValidatedConfiguration vc = new ValidatedConfiguration(() -> this.config);
-            server = new Server(vc, (exchange, buffer, record) -> events.add(new EventPayload(exchange, buffer, record)));
+            server = new Server(vc, (event, buffer, record) -> events.add(new EventPayload(event, buffer, record)));
         }
 
         public EventPayload waitForEvent() throws InterruptedException {

--- a/src/test/java/io/divolte/server/ShortTermDuplicateMemoryTest.java
+++ b/src/test/java/io/divolte/server/ShortTermDuplicateMemoryTest.java
@@ -88,49 +88,49 @@ public class ShortTermDuplicateMemoryTest {
 
     @Test
     public void shouldFlagDuplicateRequests() throws IOException, InterruptedException {
-        EventPayload event;
+        EventPayload payload;
 
         request(0);
-        event = server.waitForEvent();
-        assertEquals(false, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(false, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
 
         request(1);
-        event = server.waitForEvent();
-        assertEquals(false, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(false, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
 
         request(0);
-        event = server.waitForEvent();
-        assertEquals(true, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(true, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
     }
 
     @Test
     public void shouldForgetAboutRequestHashesAfterSomeTime() throws IOException, InterruptedException {
-        EventPayload event;
+        EventPayload payload;
 
         request(1);
-        event = server.waitForEvent();
-        assertEquals(false, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(false, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
 
         request(0);
-        event = server.waitForEvent();
-        assertEquals(false, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(false, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
 
         request(1);
-        event = server.waitForEvent();
-        assertEquals(true, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(true, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
 
         request(2);
-        event = server.waitForEvent();
-        assertEquals(false, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(false, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
 
         request(1);
-        event = server.waitForEvent();
-        assertEquals(false, event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
+        payload = server.waitForEvent();
+        assertEquals(false, payload.event.exchange.getAttachment(DUPLICATE_EVENT_KEY));
     }
 
-    private void request(int which) throws IOException {
-        URL url = new URL(String.format(URL_STRING, server.port) + URL_QUERY_STRINGS[which]);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    private void request(final int which) throws IOException {
+        final URL url = new URL(String.format(URL_STRING, server.port) + URL_QUERY_STRINGS[which]);
+        final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("GET");
         assertEquals(200, conn.getResponseCode());
     }

--- a/src/test/java/io/divolte/server/mincode/MincodeParserSamplesTest.java
+++ b/src/test/java/io/divolte/server/mincode/MincodeParserSamplesTest.java
@@ -66,7 +66,7 @@ public class MincodeParserSamplesTest {
 
     private MincodeFactory factory;
 
-    public MincodeParserSamplesTest(@SuppressWarnings("unused") final String sampleTitle,
+    public MincodeParserSamplesTest(final String sampleTitle,
                                     final JsonNode sampleJson,
                                     final String sampleMincode) {
         this.sampleJson = Objects.requireNonNull(sampleJson);

--- a/src/test/java/io/divolte/server/recordmapping/AvroGenericRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/recordmapping/AvroGenericRecordMapperTest.java
@@ -105,7 +105,7 @@ public class AvroGenericRecordMapperTest {
 
     private AvroGenericRecordMapper reader;
 
-    public AvroGenericRecordMapperTest(@SuppressWarnings("unused") final String sampleTitle,
+    public AvroGenericRecordMapperTest(final String sampleTitle,
                                        final Fixture testFixture) {
         this.testFixture = Objects.requireNonNull(testFixture);
     }


### PR DESCRIPTION
This changes the incoming request processing pool to work with instances of DivolteEvent instead of HttpServerExchange. The incoming server exchange is still captured and transferred onto the processing pool threads, but is now contained within the DivolteEvent instance.

One issue remains: we rely on a attachment on the server exchange for communicating to the record mapper whether the current record is a duplicate or not. This isn't very clean; ideally we wouldn't populate the server exchange with anything of our own. One possible solution would be to turn the context for the record mapping into an object that has the duplicate field, next to the string->object map used for memoization.