### PR TITLE
Support/0.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ group   = 'io.divolte'
 // Order matters: the version has to be after the scmVersion extension has determined the version.
 //project.version = scmVersion.version
 // Disable version resolution via the plugin; we're reevaluating the release process.
-project.version = '0.4.0-SNAPSHOT'
+project.version = '0.3.1-SNAPSHOT'
 
 sourceCompatibility = 1.8
 mainClassName = 'io.divolte.server.Server'

--- a/rpm/divolte-collector.spec
+++ b/rpm/divolte-collector.spec
@@ -6,7 +6,7 @@
 %define snapshot %{nil}%{?snapshotVersion}
 
 Name:           divolte-collector
-Version:        0.4.0
+Version:        0.3.1
 Release:        1%{?dist}
 Summary:        The Divolte click-stream collection agent.
 


### PR DESCRIPTION
This is a partial fix for #110 that at least swallows the exception and provides a Marker channel to log the event data.

I suspect the *really* right fix is to have a try/catch around IncomingRequestProcessor.process(HttpServerExchange) to ensure that pretty much nothing gets past it, but I couldn't be sure I understood the code well enough to avoid swallowing exceptions that might mess up subsequent event processing.