### PR TITLE
Migrate to Kafka's new java client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,9 @@ dependencies {
         // client which conflicts with the version via Hadoop.
         exclude group: 'com.google.http-client', module: 'google-http-client'
     }
-    compile group: 'org.apache.kafka', name:'kafka_2.11', version:'0.9.0.0'
+    // Currently on 0.8.2.0, even though 0.9.0.0 is out, because 0.9.0.0 isn't fully compatible
+    // with 0.8.X servers: Horton and Cloudera both ship 0.8, and we want to support them.
+    compile group: 'org.apache.kafka', name:'kafka-clients', version: '0.8.2.0'
     compile group: 'com.google.javascript', name:'closure-compiler', version:'v20151015'
     compile group: 'org.codehaus.groovy', name:'groovy', version: '2.4.5', classifier: 'indy'
     compile group: 'net.sf.jopt-simple', name:'jopt-simple', version: '4.9'

--- a/src/main/java/io/divolte/server/AvroRecordBuffer.java
+++ b/src/main/java/io/divolte/server/AvroRecordBuffer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.base.MoreObjects;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
@@ -110,6 +111,15 @@ public final class AvroRecordBuffer {
      */
     public int size() {
         return byteBuffer.limit();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("partyId", getPartyId())
+                .add("sessionId", getSessionId())
+                .add("size", size())
+                .toString();
     }
 
     @ParametersAreNonnullByDefault

--- a/src/main/java/io/divolte/server/Server.java
+++ b/src/main/java/io/divolte/server/Server.java
@@ -120,7 +120,7 @@ public final class Server implements Runnable {
     public void run() {
         Runtime.getRuntime().addShutdownHook(new Thread(this::shutdown));
 
-        logger.info("Starting server on {}:{}", host, port);
+        logger.info("Starting server on {}:{}", host.orElse("localhost"), port);
         undertow.start();
     }
 

--- a/src/main/java/io/divolte/server/kafka/AvroRecordBufferSerializer.java
+++ b/src/main/java/io/divolte/server/kafka/AvroRecordBufferSerializer.java
@@ -19,9 +19,11 @@ package io.divolte.server.kafka;
 import io.divolte.server.AvroRecordBuffer;
 import org.apache.kafka.common.serialization.Serializer;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+@ParametersAreNonnullByDefault
 class AvroRecordBufferSerializer implements Serializer<AvroRecordBuffer> {
     @Override
     public void configure(final Map<String, ?> configs, final boolean isKey) {

--- a/src/main/java/io/divolte/server/kafka/AvroRecordBufferSerializer.java
+++ b/src/main/java/io/divolte/server/kafka/AvroRecordBufferSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.divolte.server.kafka;
+
+import io.divolte.server.AvroRecordBuffer;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+class AvroRecordBufferSerializer implements Serializer<AvroRecordBuffer> {
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+        // Nothing to do.
+    }
+
+    @Override
+    public byte[] serialize(final String topic, final AvroRecordBuffer data) {
+        // Extract the AVRO record as a byte array.
+        // (There's no way to do this without copying the array.)
+        final ByteBuffer avroBuffer = data.getByteBuffer();
+        final byte[] avroBytes = new byte[avroBuffer.remaining()];
+        avroBuffer.get(avroBytes);
+        return avroBytes;
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do.
+    }
+}

--- a/src/main/java/io/divolte/server/kafka/DivolteIdentifierSerializer.java
+++ b/src/main/java/io/divolte/server/kafka/DivolteIdentifierSerializer.java
@@ -19,9 +19,11 @@ package io.divolte.server.kafka;
 import io.divolte.server.DivolteIdentifier;
 import org.apache.kafka.common.serialization.Serializer;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+@ParametersAreNonnullByDefault
 class DivolteIdentifierSerializer implements Serializer<DivolteIdentifier> {
     @Override
     public void configure(final Map<String, ?> configs, final boolean isKey) {

--- a/src/main/java/io/divolte/server/kafka/DivolteIdentifierSerializer.java
+++ b/src/main/java/io/divolte/server/kafka/DivolteIdentifierSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.divolte.server.kafka;
+
+import io.divolte.server.DivolteIdentifier;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+class DivolteIdentifierSerializer implements Serializer<DivolteIdentifier> {
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+        // Nothing needed here.
+    }
+
+    @Override
+    public byte[] serialize(final String topic, final DivolteIdentifier data) {
+        return data.value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public void close() {
+        // Nothing needed here.
+    }
+}

--- a/src/main/java/io/divolte/server/kafka/KafkaFlusher.java
+++ b/src/main/java/io/divolte/server/kafka/KafkaFlusher.java
@@ -137,9 +137,9 @@ public final class KafkaFlusher implements ItemProcessor<AvroRecordBuffer> {
             final Future<RecordMetadata> result = sendResults.get(i);
             try {
                 final RecordMetadata metadata = result.get();
-                if (logger.isTraceEnabled()) {
+                if (logger.isDebugEnabled()) {
                     final ProducerRecord<DivolteIdentifier, AvroRecordBuffer> record = batch.get(i);
-                    logger.trace("Finished sending event (partyId={}) to Kafka: topic/partition/offset = {}/{}/{}",
+                    logger.debug("Finished sending event (partyId={}) to Kafka: topic/partition/offset = {}/{}/{}",
                                  record.value(), metadata.topic(), metadata.partition(), metadata.offset());
                 }
             } catch (final ExecutionException e) {

--- a/src/main/java/io/divolte/server/kafka/KafkaFlusher.java
+++ b/src/main/java/io/divolte/server/kafka/KafkaFlusher.java
@@ -137,9 +137,9 @@ public final class KafkaFlusher implements ItemProcessor<AvroRecordBuffer> {
             final Future<RecordMetadata> result = sendResults.get(i);
             try {
                 final RecordMetadata metadata = result.get();
-                if (logger.isDebugEnabled()) {
+                if (logger.isTraceEnabled()) {
                     final ProducerRecord<DivolteIdentifier, AvroRecordBuffer> record = batch.get(i);
-                    logger.debug("Finished sending event (partyId={}) to Kafka: topic/partition/offset = {}/{}/{}",
+                    logger.trace("Finished sending event (partyId={}) to Kafka: topic/partition/offset = {}/{}/{}",
                                  record.value(), metadata.topic(), metadata.partition(), metadata.offset());
                 }
             } catch (final ExecutionException e) {

--- a/src/main/java/io/divolte/server/kafka/KafkaFlushingPool.java
+++ b/src/main/java/io/divolte/server/kafka/KafkaFlushingPool.java
@@ -24,9 +24,13 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Objects;
 
 @ParametersAreNonnullByDefault
 public class KafkaFlushingPool extends ProcessingPool<KafkaFlusher, AvroRecordBuffer> {
+
+    private final Producer<DivolteIdentifier, AvroRecordBuffer> producer;
+
     public KafkaFlushingPool(final ValidatedConfiguration vc) {
         this(
                 vc.configuration().kafkaFlusher.threads,
@@ -45,5 +49,12 @@ public class KafkaFlushingPool extends ProcessingPool<KafkaFlusher, AvroRecordBu
                              final String topic,
                              final Producer<DivolteIdentifier, AvroRecordBuffer> producer ) {
         super(numThreads, maxWriteQueue, maxEnqueueDelay, "Kafka Flusher", () -> new KafkaFlusher(topic, producer));
+        this.producer = Objects.requireNonNull(producer);
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        producer.close();
     }
 }

--- a/src/main/java/io/divolte/server/kafka/KafkaFlushingPool.java
+++ b/src/main/java/io/divolte/server/kafka/KafkaFlushingPool.java
@@ -17,10 +17,11 @@
 package io.divolte.server.kafka;
 
 import io.divolte.server.AvroRecordBuffer;
+import io.divolte.server.DivolteIdentifier;
 import io.divolte.server.config.ValidatedConfiguration;
 import io.divolte.server.processing.ProcessingPool;
-
-import java.util.Objects;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -28,18 +29,21 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class KafkaFlushingPool extends ProcessingPool<KafkaFlusher, AvroRecordBuffer> {
     public KafkaFlushingPool(final ValidatedConfiguration vc) {
         this(
-                Objects.requireNonNull(vc),
                 vc.configuration().kafkaFlusher.threads,
                 vc.configuration().kafkaFlusher.maxWriteQueue,
-                vc.configuration().kafkaFlusher.maxEnqueueDelay.toMillis()
+                vc.configuration().kafkaFlusher.maxEnqueueDelay.toMillis(),
+                vc.configuration().kafkaFlusher.topic,
+                new KafkaProducer<>(vc.configuration().kafkaFlusher.producer,
+                        new DivolteIdentifierSerializer(),
+                        new AvroRecordBufferSerializer())
                 );
     }
 
-    public KafkaFlushingPool(ValidatedConfiguration vc, int numThreads, int maxWriteQueue, long maxEnqueueDelay) {
-        super(numThreads, maxWriteQueue, maxEnqueueDelay, "Kafka Flusher", () -> new KafkaFlusher(vc));
-    }
-
-    public void enqueueRecord(final AvroRecordBuffer record) {
-        enqueue(record.getPartyId().value, record);
+    public KafkaFlushingPool(final int numThreads,
+                             final int maxWriteQueue,
+                             final long maxEnqueueDelay,
+                             final String topic,
+                             final Producer<DivolteIdentifier, AvroRecordBuffer> producer ) {
+        super(numThreads, maxWriteQueue, maxEnqueueDelay, "Kafka Flusher", () -> new KafkaFlusher(topic, producer));
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -248,9 +248,10 @@ divolte {
       client.id = divolte.collector
       client.id = ${?DIVOLTE_KAFKA_CLIENT_ID}
 
-      acks = 0
-      retries = 5
-      retry.backoff.ms = 200
+      acks = 1
+      retries = 0
+      compression.type = lz4
+      max.in.flight.requests.per.connection = 1
     }
   }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -243,14 +243,13 @@ divolte {
     // the Kafka producer.
     // See: http://kafka.apache.org/documentation.html#producerconfigs
     producer = {
-      metadata.broker.list = ["localhost:9092"]
-      metadata.broker.list = ${?DIVOLTE_KAFKA_BROKER_LIST}
-
+      bootstrap.servers = ["localhost:9092"]
+      bootstrap.servers = ${?DIVOLTE_KAFKA_BROKER_LIST}
       client.id = divolte.collector
       client.id = ${?DIVOLTE_KAFKA_CLIENT_ID}
 
-      request.required.acks = 0
-      message.send.max.retries = 5
+      acks = 0
+      retries = 5
       retry.backoff.ms = 200
     }
   }


### PR DESCRIPTION
This pull request updates the Kafka sink to use the new Java client for Kafka. This is pretty straightforward, with the following caveats:

 - Although async in nature and API, some aspects of the new client are blocking.
    - The producer blocks on receiving cluster metadata before attempting to send.
    - The product can apparently block in some way when its internal buffer is full.
 - The new Java clients are not compatible with older server releases. Hence we use the 0.8 client instead of 0.9 for maximum server compatibility.
 - We now share a single producer amongst all threads, which may increase contention. (The Kafka folk believe that a single shared producer performs better than multiple producers, and it turns out that trying to use multiple producers results in exceptions as they collide try to register their JMX metrics.)
 - The new producer uses different property names to the old one. This means that upgrades from the old producer will need to rename some properties in their configuration.
 - We no longer fire-and-forget with messages to Kafka. This could result in a different performance profile.
 - We now LZ4-compress traffic that the producer sends to the brokers. This will increase the CPU consumption slightly, but we've noticed that often network bandwidth is at a higher premium than CPU.