### PR TITLE
Allow to use configured (external) Kafka key & value serializers

### DIFF
--- a/src/main/java/io/divolte/server/AvroRecordBuffer.java
+++ b/src/main/java/io/divolte/server/AvroRecordBuffer.java
@@ -41,6 +41,7 @@ public final class AvroRecordBuffer {
     private final long cookieUtcOffset;
     private final DivolteIdentifier partyId;
     private final DivolteIdentifier sessionId;
+    private final GenericRecord record;
     private final ByteBuffer byteBuffer;
 
     private AvroRecordBuffer(final DivolteIdentifier partyId, final DivolteIdentifier sessionId, final long eventTime, final long cookieUtcOffset, final GenericRecord record) throws IOException {
@@ -48,6 +49,7 @@ public final class AvroRecordBuffer {
         this.sessionId = Objects.requireNonNull(sessionId);
         this.eventTime = eventTime;
         this.cookieUtcOffset = cookieUtcOffset;
+        this.record = record;
 
         /*
          * We avoid ByteArrayOutputStream as it is fully synchronized and performs
@@ -82,6 +84,10 @@ public final class AvroRecordBuffer {
 
     public long getCookieUtcOffset() {
         return cookieUtcOffset;
+    }
+
+    public GenericRecord getRecord() {
+        return record;
     }
 
     public static AvroRecordBuffer fromRecord(final DivolteIdentifier partyId, final DivolteIdentifier sessionId, final long eventTime, final long cookieUtcOffset, final GenericRecord record) {

--- a/src/main/java/io/divolte/server/kafka/KafkaFlushingPool.java
+++ b/src/main/java/io/divolte/server/kafka/KafkaFlushingPool.java
@@ -20,10 +20,13 @@ import io.divolte.server.AvroRecordBuffer;
 import io.divolte.server.DivolteIdentifier;
 import io.divolte.server.config.ValidatedConfiguration;
 import io.divolte.server.processing.ProcessingPool;
+
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+
 import java.util.Objects;
 
 @ParametersAreNonnullByDefault
@@ -37,9 +40,10 @@ public class KafkaFlushingPool extends ProcessingPool<KafkaFlusher, AvroRecordBu
                 vc.configuration().kafkaFlusher.maxWriteQueue,
                 vc.configuration().kafkaFlusher.maxEnqueueDelay.toMillis(),
                 vc.configuration().kafkaFlusher.topic,
-                new KafkaProducer<>(vc.configuration().kafkaFlusher.producer,
-                        new DivolteIdentifierSerializer(),
-                        new AvroRecordBufferSerializer())
+                new KafkaProducer<>(
+                        vc.configuration().kafkaFlusher.producer,
+                        vc.configuration().kafkaFlusher.producer.containsKey(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG) ? null : new DivolteIdentifierSerializer(),
+                        vc.configuration().kafkaFlusher.producer.containsKey(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG) ? null : new AvroRecordBufferSerializer())
                 );
     }
 


### PR DESCRIPTION
The KafkaFlusher creates key & value serializers itself, thus always serializing to byte[]. 

This change 
- allows to use the Kafka producer properties to configure a key & value serializer (f not configured, it falls back to the default ones included in the project)
- exposes the Avro GenericRecord itself so it can be used by a custom Kafka value serializer
