### PR TITLE
Write absolute mapping script path to log.

### DIFF
--- a/src/main/java/io/divolte/server/recordmapping/DslRecordMapper.java
+++ b/src/main/java/io/divolte/server/recordmapping/DslRecordMapper.java
@@ -62,12 +62,13 @@ public class DslRecordMapper implements RecordMapper {
     public DslRecordMapper(final ValidatedConfiguration vc, final String groovyFile, final Schema schema, final Optional<LookupService> geoipService) {
         this.schema = Objects.requireNonNull(schema);
 
-        logger.info("Using mapping from script file: {}", groovyFile);
-
         try {
             final DslRecordMapping mapping = new DslRecordMapping(schema, new UserAgentParserAndCache(vc), geoipService);
 
-            final String groovyScript = Files.toString(new File(groovyFile), StandardCharsets.UTF_8);
+            final File groovyFileWithPath = new File(groovyFile);
+            logger.info("Using mapping from script file: {}", groovyFileWithPath.getAbsolutePath());
+
+            final String groovyScript = Files.toString(groovyFileWithPath, StandardCharsets.UTF_8);
 
             final CompilerConfiguration compilerConfig = new CompilerConfiguration();
             compilerConfig.setScriptBaseClass("io.divolte.groovyscript.MappingBase");


### PR DESCRIPTION
This changes the diagnostic logging when locating a mapping script to catch a subtle misconfiguration that's difficult to spot without this patch.

Specifically, this configuration:

    divolte.mappings.x {
        mapping_script_file = 'some/script.groovy'
    }

is materialised into this filesystem path:

    /path/to/divolte/'some/script.groovy'

The configuration format supports double-quoted strings but not single-quoted strings. By writing the java.io.File's absolute path to the log file instead of the original configuration value, this becomes easier to spot.