### PR TITLE
Fix a potential request-handling deadlock for JSON payloads with a chunk-aligned size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     def slf4jVersion = '1.7.22'
 
     compile group: 'io.divolte', name: 'divolte-schema', version: version
-    compile group: 'io.undertow', name: 'undertow-core', version: '1.4.6.Final'
+    compile group: 'io.undertow', name: 'undertow-core', version: '1.4.7.Final'
     compile group: 'com.typesafe', name: 'config', version: '1.3.1'
     compile group: 'com.google.guava', name: 'guava', version: '21.0'
     compile group: 'org.apache.avro', name: 'avro', version: avroVersion

--- a/src/main/java/io/divolte/server/ChunkyByteBuffer.java
+++ b/src/main/java/io/divolte/server/ChunkyByteBuffer.java
@@ -105,9 +105,9 @@ public class ChunkyByteBuffer {
                             // We allocate chunks on demand, as we advance.
                             chunks[++currentChunkIndex] = ByteBuffer.allocate(CHUNK_SIZE);
                         } else {
-                            // Buffers are full.
+                            // Buffers are full; detect if we're at EOF, waiting if necessary.
                             channel.getReadSetter().set(this::waitForEndOfStream);
-                            channel.resumeReads();
+                            waitForEndOfStream(channel);
                             return;
                         }
                     }
@@ -142,7 +142,8 @@ public class ChunkyByteBuffer {
                     endOfFile(channel);
                     break;
                 case 0:
-                    // Still not sure. Wait.
+                    // Not yet sure; keep waiting.
+                    channel.resumeReads();
                     break;
                 default:
                     // Overflow. Doh.


### PR DESCRIPTION
This pull request fixes what I believe may have been a potential bug whereby handling of JSON-based events could deadlock if the request body was an exact multiple of the internal buffering chunk size (4096 bytes).

For some reason, upgrading to Undertow 1.4.7 caused internal tests to fail in the specific case where our JSON payload was the configured maximum allowed size and no content-length header was supplied. (The configured maximum allowed size for the test is the default, which happens to be an exact multiple of the chunk size.)

Despite this being triggered by switching to Undertow 1.4.7, I suspect the bug is always present when for some reason the async-channel detects EOF at the same time as the final `read()`, in which case it won't necessarily 'wake' the channel again.