### PR TITLE
Fix semantics of encoding event parameters with ‘undefined’ values.

### DIFF
--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -225,7 +225,22 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         final Optional<String> customEventParameters =
                 eventData.eventParametersProducer.get().map(Object::toString);
         assertTrue(customEventParameters.isPresent());
-        assertEquals("{\"a\":{},\"b\":\"c\",\"d\":{\"a\":[],\"b\":\"g\"},\"e\":[\"1\",\"2\"],\"f\":42,\"g\":53.2,\"h\":-37,\"i\":-7.83E-9,\"j\":true,\"k\":false,\"l\":null,\"m\":\"2015-06-13T15:49:33.002Z\",\"n\":{},\"o\":[{},{\"a\":\"b\"},{\"c\":\"d\"}],\"p\":{}}",
+        assertEquals("{\"a\":{}," +
+                     "\"b\":\"c\"," +
+                     "\"d\":{\"a\":[],\"b\":\"g\"}," +
+                     "\"e\":[\"1\",\"2\"]," +
+                     "\"f\":42," +
+                     "\"g\":53.2," +
+                     "\"h\":-37," +
+                     "\"i\":-7.83E-9," +
+                     "\"j\":true," +
+                     "\"k\":false," +
+                     "\"l\":null," +
+                     "\"m\":\"2015-06-13T15:49:33.002Z\"," +
+                     "\"n\":{}," +
+                     "\"o\":[{},{\"a\":\"b\"},{\"c\":\"d\"}]," +
+                     "\"p\":[null,null,{\"a\":\"b\"},\"custom\",null,{}]," +
+                     "\"q\":{}}",
                      customEventParameters.get());
     }
 

--- a/src/test/resources/static/quirks/test-basic-page.html
+++ b/src/test/resources/static/quirks/test-basic-page.html
@@ -26,6 +26,18 @@
   </head>
   <body>
     <script src="/divolte.js" defer async></script>
+    <script>
+        var customToJson1 = {
+            toJSON: function() {
+                return "custom"
+            }
+        };
+        var customToJson2 = {
+            toJSON: function() {
+                return undefined;
+            }
+        }
+    </script>
     <div id="custom"
          onclick="divolte.signal('custom', {
                                    a: {},
@@ -42,7 +54,8 @@
                                    m: new Date(Date.UTC(2015,5,13,15,49,33,2)),
                                    n: {},
                                    o: [ {}, { a: 'b' }, { c: 'd' } ],
-                                   p: {}
+                                   p: [ null, undefined, { a: 'b', b: undefined }, customToJson1, customToJson2, { a: customToJson2 }],
+                                   q: {}
                                  }
                                  )">Click me to fire an event!</div>
   </body>

--- a/src/test/resources/static/strict/test-basic-page.html
+++ b/src/test/resources/static/strict/test-basic-page.html
@@ -27,6 +27,18 @@
   </head>
   <body>
     <script src="/divolte.js" defer async></script>
+    <script>
+        var customToJson1 = {
+            toJSON: function() {
+                return "custom"
+            }
+        };
+        var customToJson2 = {
+            toJSON: function() {
+                return undefined;
+            }
+        }
+    </script>
     <div id="custom"
          onclick="divolte.signal('custom', {
                                    a: {},
@@ -43,7 +55,8 @@
                                    m: new Date(Date.UTC(2015,5,13,15,49,33,2)),
                                    n: {},
                                    o: [ {}, { a: 'b' }, { c: 'd' } ],
-                                   p: {}
+                                   p: [ null, undefined, { a: 'b', b: undefined }, customToJson1, customToJson2, { a: customToJson2 }],
+                                   q: {}
                                  }
                                  )">Click me to fire an event!</div>
   </body>


### PR DESCRIPTION
This pull request improves handling of event parameters that include `undefined` values so that it matches the behaviour of `JSON.stringify()`. Prior to this pull request `undefined` values would trigger a (Javascript-side) exception when encountered.

The new behaviour is:

 - Properties on objects with a value of `undefined` cause the property to be elided.
 - `undefined` values in arrays are converted to `null`.

If an object has a custom `.toJSON()` implementation, these rules apply _after_ it has been substituted by the return value of its `.toJSON()` method.