### PR TITLE
Consistent page-view handling during forward/back browser navigation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -207,6 +207,22 @@ Property: ``divolte.global.server.serve_static_resources``
       serve_static_resources = false
     }
 
+Property: ``divolte.global.server.debug_requests``
+""""""""""""""""""""""""""""""""""""""""""""""""""
+:Description:
+  When true Divolte Collector logs (with great verbosity) all HTTP requests and responses.
+  This is intended purely for development or debugging and should never be enabled on a
+  production system.
+:Default:
+  :code:`false`
+:Example:
+
+  .. code-block:: none
+
+    divolte.global.server {
+      debug_requests = true
+    }
+
 Global Mapper Settings (``divolte.global.mapper``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This section controls global settings related to the processing of incoming requests after they have been received by the server. Incoming requests for Divolte Collector are responded to as quickly as possible, with mapping and flushing occurring in the background.

--- a/src/main/java/io/divolte/server/Server.java
+++ b/src/main/java/io/divolte/server/Server.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.undertow.server.handlers.*;
 import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,10 +39,6 @@ import io.divolte.server.config.ValidatedConfiguration;
 import io.divolte.server.processing.ProcessingPool;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
-import io.undertow.server.handlers.CanonicalPathHandler;
-import io.undertow.server.handlers.GracefulShutdownHandler;
-import io.undertow.server.handlers.PathHandler;
-import io.undertow.server.handlers.SetHeaderHandler;
 import io.undertow.server.handlers.cache.DirectBufferCache;
 import io.undertow.server.handlers.resource.CachingResourceManager;
 import io.undertow.server.handlers.resource.ClassPathResourceManager;
@@ -142,7 +139,9 @@ public final class Server implements Runnable {
         shutdownHandler = rootHandler;
         undertow = Undertow.builder()
                            .addHttpListener(port, host.orElse(null))
-                           .setHandler(rootHandler)
+                           .setHandler(vc.configuration().global.server.debugRequests
+                               ? new RequestDumpingHandler(rootHandler)
+                               : rootHandler)
                            .build();
     }
 

--- a/src/main/java/io/divolte/server/config/ServerConfiguration.java
+++ b/src/main/java/io/divolte/server/config/ServerConfiguration.java
@@ -15,16 +15,19 @@ public final class ServerConfiguration {
     public final int port;
     public final boolean useXForwardedFor;
     public final boolean serveStaticResources;
+    public final boolean debugRequests;
 
     @JsonCreator
     ServerConfiguration(final Optional<String> host,
                         final int port,
                         @JsonProperty("use_x_forwarded_for") final boolean useXForwardedFor,
-                        final boolean serveStaticResources) {
+                        final boolean serveStaticResources,
+                        final boolean debugRequests) {
         this.host = Objects.requireNonNull(host);
         this.port = port;
         this.useXForwardedFor = useXForwardedFor;
         this.serveStaticResources = serveStaticResources;
+        this.debugRequests = debugRequests;
     }
 
     @Override
@@ -34,6 +37,7 @@ public final class ServerConfiguration {
                 .add("port", port)
                 .add("useXForwardedFor", useXForwardedFor)
                 .add("serverStaticResources", serveStaticResources)
+                .add("debugRequests", debugRequests)
                 .toString();
     }
 }

--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -611,7 +611,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     sessionId = generateId(true);
   }
   if (isServerPageView) {
-    log("Using server-provided pageview identifier.")
+    log("Using server-provided pageview identifier.", pageViewId);
   } else {
     pageViewId = generateId(false)
   }
@@ -688,6 +688,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     var pendingEvents = this.queue;
     pendingEvents.push(event);
     if (1 === pendingEvents.length) {
+      log("No pending events; delivering immediately.", event);
       this.deliverFirstPendingEvent();
     }
   };
@@ -699,6 +700,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     var signalQueue = this;
     var image = new Image(1,1);
     var firstPendingEvent = signalQueue.queue[0];
+    log("Delivering pending event.", firstPendingEvent);
     var completionHandler = withTimeout(function() {
       // We can't use onFirstPendingEventCompleted directly because 'this' isn't bound correctly.
       // (And sadly, function.bind() isn't available universally.)
@@ -716,12 +718,17 @@ var AUTO_PAGE_VIEW_EVENT = true;
    * Handler for when the first event in the queue has been completed.
    */
   SignalQueue.prototype.onFirstPendingEventCompleted = function() {
+    log("Marking pending event as complete.");
     // Delete the first event from the queue.
     var pendingEvents = this.queue;
     pendingEvents.shift();
     // If there are still pending events, schedule the next.
-    if (0 < pendingEvents.length) {
+    var remainingEvents = pendingEvents.length;
+    if (0 < remainingEvents) {
+      log("Processing next event; remaining count:", remainingEvents);
       this.deliverFirstPendingEvent();
+    } else {
+      log("All pending events have been delivered.");
     }
   };
 

--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -638,9 +638,9 @@ var AUTO_PAGE_VIEW_EVENT = true;
    * Utility function for invoking a callback after a specific timeout if it
    * hasn't already been invoked.
    *
-   * @param {!function(): undefined} callback
+   * @param {function(): undefined} callback
    *        the function to invoke after the timout if it hasn't already been.
-   * @return {!function(): undefined}
+   * @return {function(): undefined}
    *         a function to be used as callback instead of the wrapped function.
    */
   var withTimeout = function(callback) {
@@ -884,7 +884,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
      * Set the name of the property that the next record will be assigned
      * to.
      * @private
-     * @param {!string} fieldName the property name.
+     * @param {string} fieldName the property name.
      */
     Mincoder.prototype.setNextFieldName = function(fieldName) {
       this.pendingFieldName = fieldName;
@@ -892,7 +892,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     /**
      * Add a record to the buffer.
      * @private
-     * @param {!string} recordType the type of the record.
+     * @param {string} recordType the type of the record.
      * @param {string=} payload    the (optional) payload for this record.
      */
     Mincoder.prototype.addRecord = function(recordType, payload) {
@@ -908,7 +908,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     };
     /**
      * Encode a variable-length string value.
-     * @param {!string} s the string to encode.
+     * @param {string} s the string to encode.
      */
     Mincoder.escapeString = function() {
       /**
@@ -924,7 +924,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     /**
      * Encode a string.
      * @private
-     * @param {!string} s the string to encode as a record.
+     * @param {string} s the string to encode as a record.
      */
     Mincoder.prototype.encodeString = function(s) {
       this.addRecord('s', Mincoder.escapeString(s) + '!');
@@ -932,7 +932,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     /**
      * Encode a number.
      * @private
-     * @param {!number} n the number to encode as a record.
+     * @param {number} n the number to encode as a record.
      */
     Mincoder.prototype.encodeNumber = function(n) {
       if (isFinite(n)) {
@@ -956,7 +956,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     /**
      * Encode a boolean.
      * @private
-     * @param b {!boolean} b the boolean to encode as a record.
+     * @param b {boolean} b the boolean to encode as a record.
      */
     Mincoder.prototype.encodeBoolean = function(b) {
       this.addRecord(b ? 't' : 'f');
@@ -989,9 +989,9 @@ var AUTO_PAGE_VIEW_EVENT = true;
     Mincoder.prototype.encodeDate = function() {
       /**
        * Zero-pad a number.
-       * @param {!number} len the length to pad to.
-       * @param {!number} n   the number to
-       * @returns {!string} the number, zero-padded to the required length
+       * @param {number} len the length to pad to.
+       * @param {number} n   the number to
+       * @returns {string} the number, zero-padded to the required length
        */
       var pad = function(len, n) {
             var result = n.toString();
@@ -1098,11 +1098,11 @@ var AUTO_PAGE_VIEW_EVENT = true;
    * server. This function returns immediately, the event itself is logged
    * asynchronously.
    *
-   * @param {!string} type The type of event to log.
+   * @param {string} type The type of event to log.
    * @param {Object=} [customParameters]
    *    Optional object containing custom parameters to log alongside the event.
    *
-   * @return {string} the unique event identifier for this event.
+   * @return {?string} the unique event identifier for this event.
    */
   var signal = function(type, customParameters) {
     // Only proceed if we have an event type.
@@ -1204,7 +1204,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
       signalQueue.enqueue(queryString);
     } else {
       warn("Ignoring event with no type.");
-      eventId = undefined;
+      eventId = null;
     }
     return eventId;
   };
@@ -1214,11 +1214,11 @@ var AUTO_PAGE_VIEW_EVENT = true;
    * @const
    * @type {{partyId: string,
    *         sessionId: string,
-   *         pageViewId: string,
+   *         pageViewId: ?string,
    *         isNewPartyId: boolean,
    *         isFirstInSession: boolean,
    *         isServerPageView: boolean,
-   *         signal: function(!string,Object=): string}}
+   *         signal: function(string,Object=): ?string}}
    */
   var divolte = {
     'partyId':          partyId,

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -46,6 +46,10 @@ divolte {
 
       // When true Divolte Collector serves a static test page at /.
       serve_static_resources = true
+
+      // Whether requests (and their response) should be logged for debugging.
+      // This is for testing purposes only; it should never be enabled in production.
+      debug_requests = false
     }
 
     mapper {

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -74,7 +74,7 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
     }
 
     @Test
-    public void shouldRegenerateIDsOnForwardBackNavigation() throws Exception {
+    public void shouldRegenerateIDsOnBackNavigation() throws Exception {
         doSetUp();
         Preconditions.checkState(null != driver && null != server);
 
@@ -82,14 +82,24 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         final Runnable[] actions = {
                 () -> gotoPage(BASIC),
                 () -> gotoPage(BASIC_COPY),
+                driver.navigate()::back,
+        };
+        final int numberOfUniquePageViewIDs = uniquePageViewIdsForSeriesOfActions(actions);
+        assertEquals(actions.length, numberOfUniquePageViewIDs);
+    }
+
+    @Test
+    public void shouldRegenerateIDsOnForwardNavigation() throws Exception {
+        doSetUp();
+        Preconditions.checkState(null != driver && null != server);
+
+        // Navigate to the same page twice
+        final Runnable[] actions = {
                 () -> gotoPage(BASIC),
-                driver.navigate()::back,
-                driver.navigate()::back,
-                driver.navigate()::forward,
+                () -> gotoPage(BASIC_COPY),
                 driver.navigate()::back,
                 driver.navigate()::forward,
-                driver.navigate()::forward
-                };
+        };
         final int numberOfUniquePageViewIDs = uniquePageViewIdsForSeriesOfActions(actions);
         assertEquals(actions.length, numberOfUniquePageViewIDs);
     }


### PR DESCRIPTION
This pull requests introduces the following changes:

 - Additional browser logging, when enabled, to better trace delivery of events.
 - A new configuration item on the server to enable dumping of all HTTP requests and responses. This is intended only for development and debugging scenarios, and defaults to off (where it has no overhead).
 - Handling of forward/back navigation on browsers that use a bfcache-style mechanism, resolving issue #157.