### PR TITLE
Support waiting for previously signalled events to be delivered

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -750,7 +750,7 @@ Browser source property: ``javascript.event_timeout``
   sending the next. This property specifies a timeout after which the tag proceeds with the next event even if the previous
   has not been delivered yet.
 :Default:
-  :code:`500 milliseconds`
+  :code:`750 milliseconds`
 :Example:
 
   .. code-block:: none

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -632,6 +632,24 @@ Browser source property: ``session_timeout``
       session_timeout = 1 hour
     }
 
+Browser source property: ``http_response_delay``
+""""""""""""""""""""""""""""""""""""""""""""""""
+:Description:
+  This property can be used to introduce an artificial delay when an event is received
+  before sending the HTTP response. This is intended only for for testing purposes, and
+  should never be changed from the default in production. (Note that only the HTTP
+  response is delayed; the event is processed internally without delay.)
+:Default:
+  0 seconds
+:Example:
+
+  .. code-block:: none
+
+    divolte.sources.a_source {
+      type = browser
+      http_response_delay = 2 seconds
+    }
+
 Browser source property: ``cookie_domain``
 """"""""""""""""""""""""""""""""""""""""""
 :Description:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -530,6 +530,18 @@ events:
 
 The first argument to the :samp:`divolte.signal({...})` function is the type of event, while the second argument is an arbitrary object containing custom parameters associated with the event. Storing the event and its parameters into the configured Avro schema is controlled via mapping; see the :doc:`mapping_reference` chapter for details.
 
+In addition to signalling events the tag provides an API for waiting until all previously signalled events have been delivered:
+
+.. code-block:: html
+
+  <script>
+    divolte.whenCommitted(function() {
+      // Invoked when previously signalled events have been delivered.
+    }, 1000);
+  </script>
+
+The first argument is a callback that will be invoked and the second argument is an optional timeout (specified in milliseconds) after which the callback should be invoked anyway. This is useful for temporarily delaying click-throughs or other user interactions that would normally lead to the page being unloaded and aborting the delivery of recently signalled events.
+
 Browser sources are able to detect some cases of corruption in the event data. The most common source of this is due to URLs being truncated, but there are also other sources of corruption between the client and the server. Corrupted events are flagged as such but still made available for mapping. (Mappings may choose to discard corrupted events, but by default they are processed normally.)
 
 Within the namespace for a browser source properties are used to configure it.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -731,6 +731,23 @@ Browser source property: ``javascript.auto_page_view_event``
       javascript.auto_page_view_event = false
     }
 
+Browser source property: ``javascript.event_timeout``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+:Description:
+  The JavaScript tag delivers events in the order they are generated, waiting for the previous event to be delivered before
+  sending the next. This property specifies a timeout after which the tag proceeds with the next event even if the previous
+  has not been delivered yet.
+:Default:
+  :code:`500 milliseconds`
+:Example:
+
+  .. code-block:: none
+
+    divolte.sources.a_source {
+      type = browser
+      javascript.event_timeout = 1 second
+    }
+
 JSON Sources
 ^^^^^^^^^^^^
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -530,17 +530,17 @@ events:
 
 The first argument to the :samp:`divolte.signal({...})` function is the type of event, while the second argument is an arbitrary object containing custom parameters associated with the event. Storing the event and its parameters into the configured Avro schema is controlled via mapping; see the :doc:`mapping_reference` chapter for details.
 
-In addition to signalling events the tag provides an API for waiting until all previously signalled events have been delivered:
+Signalled events are delivered to the browser source by the page in the background in the order they were signalled. Any pending events not yet delivered may be discarded if the page is closed or the user navigates to a new page. The tag provides an API for the page to detect when it is safe to leave the page:
 
 .. code-block:: html
 
   <script>
     divolte.whenCommitted(function() {
-      // Invoked when previously signalled events have been delivered.
+      // Invoked when previously signalled events are no longer in danger of being discarded.
     }, 1000);
   </script>
 
-The first argument is a callback that will be invoked and the second argument is an optional timeout (specified in milliseconds) after which the callback should be invoked anyway. This is useful for temporarily delaying click-throughs or other user interactions that would normally lead to the page being unloaded and aborting the delivery of recently signalled events.
+The first argument is a callback that will be invoked when it is safe to leave the page without losing previously signalled events. The second argument is an optional timeout (specified in milliseconds) after which the callback will be invoked even if previously signalled events may be dropped. A timeout can occur, for example, if it is taking too long to deliver events to the browser source.
 
 Browser sources are able to detect some cases of corruption in the event data. The most common source of this is due to URLs being truncated, but there are also other sources of corruption between the client and the server. Corrupted events are flagged as such but still made available for mapping. (Mappings may choose to discard corrupted events, but by default they are processed normally.)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -297,6 +297,45 @@ In order to use the custom events in your mapping, map values onto fields like t
    */
   map { parse eventParameter('foo') to int32 } onto 'intField'
 
+Custom events are delivered in the background in the order they are signalled. If the user navigates away from the current page, normally the queue is discarded because the Javascript is unloaded and stops running. This can pose problems when instrumenting links that lead to a new page: navigation to the new page can occur before the event has been delivered. So help with this it's possible to register a callback that will be invoked when all pending events have been delivered:
+
+.. code-block:: javascript
+
+  // The first argument is a callback; the second (optional) argument
+  // is a timeout (specified in milliseconds) after which the callback
+  // should be invoked even if all events prior to the callback being
+  // registered have not been delivered.
+  divolte.whenCommitted(function () {
+    window.alert("Pending events have been flushed, or took longer than we're willing to wait.");
+  }, 1000);
+
+This allows for click-through events to be signalled using something like:
+
+.. code-block:: html
+
+  <script>
+    var clickThrough = function(link) {
+      var linkDestination = link.getAttribute("href");
+      divolte.signal("clickThrough", {"destination": linkDestination});
+      divolte.whenCommitted(function () {
+        window.location = linkDestination;
+      }, 1000);
+      return false;
+    };
+  </script>
+  <!--
+    == In this example, the 'click' event triggers an event and is cancelled.
+    == Once the event has been flushed, the browser navigates to the intended
+    == destination.
+    -->
+  <a href="?foobar"
+     onclick="return clickThrough(this);">Go to next page…</a>
+
+.. note::
+
+  Instrumenting click-through links is complexer than this example implies. A production example would detect
+  whether the user is opening a link in a new tab or window and react accordingly.
+
 Writing to HDFS
 ===============
 So far, we've been writing our data to the local filesystem in :file:`/tmp`. Although this works it not the intended use of Divolte Collector. The aim is to write the clickstream data to HDFS, such that it is safely and redundantly stored and available for processing using any tool available that knows how to process Avro files (e.g. Apache Hive or Apache Spark). It is trivial to configure Divolte Collector to write to HDFS, assuming you have a working HDFS instance setup. (Setting this up is out of the scope of this getting started guide. There are many great resources to be found on the internet about getting started with and running Hadoop and HDFS.)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -328,7 +328,7 @@ This allows for click-through events to be signalled using something like:
     == Once the event has been flushed, the browser navigates to the intended
     == destination.
     -->
-  <a href="?foobar"
+  <a href="next-page.html"
      onclick="return clickThrough(this);">Go to next page…</a>
 
 .. note::

--- a/src/main/java/io/divolte/server/DelayingStreamSinkConduit.java
+++ b/src/main/java/io/divolte/server/DelayingStreamSinkConduit.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.divolte.server;
+
+import io.undertow.util.WorkerUtils;
+import org.xnio.channels.StreamSourceChannel;
+import org.xnio.conduits.AbstractStreamSinkConduit;
+import org.xnio.conduits.StreamSinkConduit;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.concurrent.TimeUnit;
+
+class DelayingStreamSinkConduit extends AbstractStreamSinkConduit<StreamSinkConduit> {
+    private static final int NANOS_PER_SECOND = (int) TimeUnit.SECONDS.toNanos(1);
+
+    private final long blockUntil;
+
+    public DelayingStreamSinkConduit(final StreamSinkConduit next, final long delay, final TimeUnit timeUnit) {
+        super(next);
+        blockUntil = System.nanoTime() + timeUnit.toNanos(delay);
+    }
+
+    private boolean writesResumed;
+    private boolean scheduled;
+
+    @Override
+    public int write(final ByteBuffer src) throws IOException {
+        return canSend() ? super.write(src) : 0;
+    }
+
+    @Override
+    public long transferFrom(final FileChannel src, final long position, final long count) throws IOException {
+        return canSend() ? super.transferFrom(src, position, count) : 0;
+    }
+
+    @Override
+    public long transferFrom(final StreamSourceChannel source, final long count, final ByteBuffer throughBuffer) throws IOException {
+        return canSend() ? super.transferFrom(source, count, throughBuffer) : 0;
+    }
+
+    @Override
+    public long write(final ByteBuffer[] srcs, final int offs, final int len) throws IOException {
+        return canSend() ? super.write(srcs, offs, len) : 0;
+    }
+
+    @Override
+    public int writeFinal(final ByteBuffer src) throws IOException {
+        return canSend() ? super.writeFinal(src) : 0;
+    }
+
+    @Override
+    public long writeFinal(final ByteBuffer[] srcs, final int offs, final int len) throws IOException {
+        return canSend() ? super.writeFinal(srcs, offs, len) : 0;
+    }
+
+    @Override
+    public void resumeWrites() {
+        writesResumed = true;
+        if (canSend()) {
+            super.resumeWrites();
+        }
+    }
+
+    @Override
+    public void suspendWrites() {
+        writesResumed = false;
+        super.suspendWrites();
+    }
+
+    @Override
+    public void wakeupWrites() {
+        writesResumed = true;
+        if (canSend()) {
+            super.wakeupWrites();
+        }
+    }
+
+    @Override
+    public boolean isWriteResumed() {
+        return writesResumed;
+    }
+
+    @Override
+    public void awaitWritable() throws IOException {
+        final long remaining = blockUntil - System.nanoTime();
+        if (0 < remaining) {
+            try {
+                Thread.sleep(remaining / NANOS_PER_SECOND, (int)(remaining % NANOS_PER_SECOND));
+            } catch (final InterruptedException e) {
+                throw new InterruptedIOException();
+            }
+        }
+        super.awaitWritable();
+    }
+
+    @Override
+    public void awaitWritable(final long time, final TimeUnit timeUnit) throws IOException {
+        final long startTime = System.nanoTime();
+        final long remaining = blockUntil - startTime;
+        if (0 < remaining) {
+            try {
+                final long sleepNanos = Math.min(remaining, timeUnit.toNanos(time));
+                Thread.sleep(sleepNanos / NANOS_PER_SECOND, (int)(sleepNanos % NANOS_PER_SECOND));
+            } catch (final InterruptedException e) {
+                throw new InterruptedIOException();
+            }
+            final long elapsed = System.nanoTime() - startTime;
+            final long stillRemaining = timeUnit.toNanos(time) - elapsed;
+            if (0 < stillRemaining) {
+                super.awaitWritable(stillRemaining, TimeUnit.NANOSECONDS);
+            }
+        } else {
+            super.awaitWritable(time, timeUnit);
+        }
+    }
+
+    private boolean canSend() {
+        final long remaining = blockUntil - System.nanoTime();
+        final boolean canSend = 0 > remaining;
+        if (!canSend && writesResumed) {
+            handleWritesResumedWhenBlocked();
+        }
+        return canSend;
+    }
+
+    private void handleWritesResumedWhenBlocked() {
+        if (!scheduled) {
+            scheduled = true;
+            next.suspendWrites();
+            final long remaining = blockUntil - System.nanoTime();
+            WorkerUtils.executeAfter(getWriteThread(), () -> {
+                scheduled = false;
+                if (writesResumed) {
+                    next.wakeupWrites();
+                }
+            }, remaining, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/src/main/java/io/divolte/server/ResponseDelayingHandler.java
+++ b/src/main/java/io/divolte/server/ResponseDelayingHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.divolte.server;
+
+import io.undertow.server.ConduitWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.ConduitFactory;
+import org.xnio.conduits.StreamSinkConduit;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Handler that delays responses.
+ */
+@ParametersAreNonnullByDefault
+public class ResponseDelayingHandler implements HttpHandler {
+
+    private final HttpHandler next;
+    private final long delayMilliseconds;
+
+    private final ConduitWrapper<StreamSinkConduit> WRAPPER = new ConduitWrapper<StreamSinkConduit>() {
+        @Override
+        public StreamSinkConduit wrap(final ConduitFactory<StreamSinkConduit> factory, final HttpServerExchange exchange) {
+            return new DelayingStreamSinkConduit(factory.create(), delayMilliseconds, TimeUnit.MILLISECONDS);
+        }
+    };
+
+    public ResponseDelayingHandler(final HttpHandler next, final long delay, final TimeUnit timeUnit) {
+        this.next = Objects.requireNonNull(next);
+        this.delayMilliseconds = timeUnit.toMillis(delay);
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        exchange.addResponseWrapper(WRAPPER);
+        next.handleRequest(exchange);
+    }
+}

--- a/src/main/java/io/divolte/server/config/BrowserSourceConfiguration.java
+++ b/src/main/java/io/divolte/server/config/BrowserSourceConfiguration.java
@@ -24,6 +24,7 @@ public class BrowserSourceConfiguration extends SourceConfiguration {
     private static final String DEFAULT_SESSION_TIMEOUT = "30 minutes";
     private static final String DEFAULT_PREFIX = "/";
     private static final String DEFAULT_EVENT_SUFFIX = "csc-event";
+    private static final String DEFAULT_HTTP_RESPONSE_DELAY = "0 seconds";
 
     public static final BrowserSourceConfiguration DEFAULT_BROWSER_SOURCE_CONFIGURATION = new BrowserSourceConfiguration(
             DEFAULT_PREFIX,
@@ -33,6 +34,7 @@ public class BrowserSourceConfiguration extends SourceConfiguration {
             DurationDeserializer.parseDuration(DEFAULT_PARTY_TIMEOUT),
             DEFAULT_SESSION_COOKIE,
             DurationDeserializer.parseDuration(DEFAULT_SESSION_TIMEOUT),
+            DurationDeserializer.parseDuration(DEFAULT_HTTP_RESPONSE_DELAY),
             JavascriptConfiguration.DEFAULT_JAVASCRIPT_CONFIGURATION);
 
     public final String prefix;
@@ -42,6 +44,7 @@ public class BrowserSourceConfiguration extends SourceConfiguration {
     public final Duration partyTimeout;
     public final String sessionCookie;
     public final Duration sessionTimeout;
+    public final Duration httpResponseDelay;
 
     @Valid
     public final JavascriptConfiguration javascript;
@@ -55,6 +58,7 @@ public class BrowserSourceConfiguration extends SourceConfiguration {
                                @JsonProperty(defaultValue=DEFAULT_PARTY_TIMEOUT) final Duration partyTimeout,
                                @JsonProperty(defaultValue=DEFAULT_SESSION_COOKIE) final String sessionCookie,
                                @JsonProperty(defaultValue=DEFAULT_SESSION_TIMEOUT) final Duration sessionTimeout,
+                               @JsonProperty(defaultValue=DEFAULT_HTTP_RESPONSE_DELAY) final Duration httpResponseDelay,
                                final JavascriptConfiguration javascript) {
         // TODO: register a custom deserializer with Jackson that uses the defaultValue property from the annotation to fix this
         this.prefix = Optional.ofNullable(prefix).map(BrowserSourceConfiguration::ensureTrailingSlash).orElse(DEFAULT_PREFIX);
@@ -64,6 +68,7 @@ public class BrowserSourceConfiguration extends SourceConfiguration {
         this.partyTimeout = Optional.ofNullable(partyTimeout).orElseGet(() -> DurationDeserializer.parseDuration(DEFAULT_PARTY_TIMEOUT));
         this.sessionCookie = Optional.ofNullable(sessionCookie).orElse(DEFAULT_SESSION_COOKIE);
         this.sessionTimeout = Optional.ofNullable(sessionTimeout).orElseGet(() -> DurationDeserializer.parseDuration(DEFAULT_SESSION_TIMEOUT));
+        this.httpResponseDelay = Optional.ofNullable(httpResponseDelay).orElseGet(() -> DurationDeserializer.parseDuration(DEFAULT_HTTP_RESPONSE_DELAY));
         this.javascript = Optional.ofNullable(javascript).orElse(JavascriptConfiguration.DEFAULT_JAVASCRIPT_CONFIGURATION);
     }
 
@@ -81,6 +86,7 @@ public class BrowserSourceConfiguration extends SourceConfiguration {
                 .add("partyTimeout", partyTimeout)
                 .add("sessionCookie", sessionCookie)
                 .add("sessionTimeout", sessionTimeout)
+                .add("httpResponseDelay", httpResponseDelay)
                 .add("javascript", javascript);
     }
 

--- a/src/main/java/io/divolte/server/config/JavascriptConfiguration.java
+++ b/src/main/java/io/divolte/server/config/JavascriptConfiguration.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
+import java.time.Duration;
 import java.util.Optional;
 
 @ParametersAreNonnullByDefault
@@ -19,12 +20,14 @@ public final class JavascriptConfiguration {
     private static final String DEFAULT_LOGGING = "false";
     private static final String DEFAULT_DEBUG = "false";
     private static final String DEFAULT_AUTO_PAGE_VIEW_EVENT = "true";
+    private static final String DEFAULT_EVENT_TIMEOUT = "500 milliseconds";
 
     static final JavascriptConfiguration DEFAULT_JAVASCRIPT_CONFIGURATION =
             new JavascriptConfiguration(DEFAULT_NAME,
                                         Boolean.parseBoolean(DEFAULT_LOGGING),
                                         Boolean.parseBoolean(DEFAULT_DEBUG),
-                                        Boolean.parseBoolean(DEFAULT_AUTO_PAGE_VIEW_EVENT));
+                                        Boolean.parseBoolean(DEFAULT_AUTO_PAGE_VIEW_EVENT),
+                                        DurationDeserializer.parseDuration(DEFAULT_EVENT_TIMEOUT));
 
     @NotNull @NotEmpty @Pattern(regexp="^[A-Za-z0-9_-]+\\.js$")
     public final String name;
@@ -32,18 +35,21 @@ public final class JavascriptConfiguration {
     public final boolean logging;
     public final boolean debug;
     public final boolean autoPageViewEvent;
+    public final Duration eventTimeout;
 
     @JsonCreator
     @ParametersAreNullableByDefault
     JavascriptConfiguration(@JsonProperty(defaultValue=DEFAULT_NAME) final String name,
                             @JsonProperty(defaultValue=DEFAULT_LOGGING) final Boolean logging,
                             @JsonProperty(defaultValue=DEFAULT_DEBUG) final Boolean debug,
-                            @JsonProperty(defaultValue=DEFAULT_AUTO_PAGE_VIEW_EVENT) final Boolean autoPageViewEvent) {
+                            @JsonProperty(defaultValue=DEFAULT_AUTO_PAGE_VIEW_EVENT) final Boolean autoPageViewEvent,
+                            @JsonProperty(defaultValue=DEFAULT_EVENT_TIMEOUT) final Duration eventTimeout) {
         // TODO: register a custom deserializer with Jackson that uses the defaultValue property from the annotation to fix this
         this.name = Optional.ofNullable(name).orElse(DEFAULT_NAME);
         this.logging = Optional.ofNullable(logging).orElseGet(() -> Boolean.valueOf(DEFAULT_LOGGING));
         this.debug = Optional.ofNullable(debug).orElseGet(() -> Boolean.valueOf(DEFAULT_DEBUG));
         this.autoPageViewEvent = Optional.ofNullable(autoPageViewEvent).orElseGet(() -> Boolean.valueOf(DEFAULT_AUTO_PAGE_VIEW_EVENT));
+        this.eventTimeout = Optional.ofNullable(eventTimeout).orElseGet(() -> DurationDeserializer.parseDuration(DEFAULT_EVENT_TIMEOUT));
     }
 
     @Override
@@ -53,6 +59,7 @@ public final class JavascriptConfiguration {
                 .add("logging", logging)
                 .add("debug", debug)
                 .add("autoPageViewEvent", autoPageViewEvent)
+                .add("eventTimeout", eventTimeout)
                 .toString();
     }
 }

--- a/src/main/java/io/divolte/server/config/JavascriptConfiguration.java
+++ b/src/main/java/io/divolte/server/config/JavascriptConfiguration.java
@@ -20,7 +20,7 @@ public final class JavascriptConfiguration {
     private static final String DEFAULT_LOGGING = "false";
     private static final String DEFAULT_DEBUG = "false";
     private static final String DEFAULT_AUTO_PAGE_VIEW_EVENT = "true";
-    private static final String DEFAULT_EVENT_TIMEOUT = "500 milliseconds";
+    private static final String DEFAULT_EVENT_TIMEOUT = "750 milliseconds";
 
     static final JavascriptConfiguration DEFAULT_JAVASCRIPT_CONFIGURATION =
             new JavascriptConfiguration(DEFAULT_NAME,

--- a/src/main/java/io/divolte/server/js/TrackingJavaScriptResource.java
+++ b/src/main/java/io/divolte/server/js/TrackingJavaScriptResource.java
@@ -25,10 +25,13 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.IOException;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 
 @ParametersAreNonnullByDefault
 public class TrackingJavaScriptResource extends JavaScriptResource {
     private static final Logger logger = LoggerFactory.getLogger(TrackingJavaScriptResource.class);
+
+    private static final int NANOS_PER_SECOND = (int) TimeUnit.SECONDS.toNanos(1);
 
     private static final String SCRIPT_CONSTANT_NAME = "SCRIPT_NAME";
 
@@ -53,6 +56,8 @@ public class TrackingJavaScriptResource extends JavaScriptResource {
         builder.put(SCRIPT_CONSTANT_NAME, browserSourceConfiguration.javascript.name);
         builder.put("EVENT_SUFFIX", browserSourceConfiguration.eventSuffix);
         builder.put("AUTO_PAGE_VIEW_EVENT", browserSourceConfiguration.javascript.autoPageViewEvent);
+        builder.put("EVENT_TIMEOUT_SECONDS", browserSourceConfiguration.javascript.eventTimeout.getSeconds() +
+                                             browserSourceConfiguration.javascript.eventTimeout.getNano() / (double)NANOS_PER_SECOND);
         return builder.build();
     }
 

--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -700,7 +700,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
     log("Queueing item for processing; " + pendingEvents.length + " already pending.", item);
     pendingEvents.push(item);
     if (1 === pendingEvents.length) {
-      this.deliverFirstPendingEvent(item);
+      this.processNextItem();
     }
   };
   /**

--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -1289,7 +1289,8 @@ var AUTO_PAGE_VIEW_EVENT = true;
    *         isNewPartyId: boolean,
    *         isFirstInSession: boolean,
    *         isServerPageView: boolean,
-   *         signal: function(string,Object=): ?string}}
+   *         signal: function(string,Object=): ?string,
+   *         whenCommitted: function(function()): undefined}};
    */
   var divolte = {
     'partyId':          partyId,

--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -1149,8 +1149,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
    *
    *  - A prior event is successfully flushed.
    *  - An error occurs flushed the prior event. (No retry is attempted.)
-   *  - It takes too long (1 second by default) for the prior event to be
-   *    flushed.
+   *  - It takes too long for the prior event to be flushed.
    *
    * @param {string} type The type of event to log.
    * @param {Object=} [customParameters]

--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -697,7 +697,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
    */
   SignalQueue.prototype.enqueue = function(item) {
     var pendingEvents = this.queue;
-    log("Queueing item for processing; " + pendingEvents.length + " already pending.", item);
+    log("Queueing item for processing; " + pendingEvents.length + " currently pending.", item);
     pendingEvents.push(item);
     if (1 === pendingEvents.length) {
       this.processNextItem();

--- a/src/test/java/io/divolte/server/DslRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/DslRecordMapperTest.java
@@ -557,7 +557,7 @@ public class DslRecordMapperTest {
     @After
     public void shutdown() throws IOException {
         if (server != null) {
-            server.server.shutdown();
+            server.shutdown();
         }
         if (mappingFile != null) {
             Files.delete(mappingFile.toPath());

--- a/src/test/java/io/divolte/server/JsonSourceTest.java
+++ b/src/test/java/io/divolte/server/JsonSourceTest.java
@@ -67,7 +67,7 @@ public class JsonSourceTest {
     }
 
     private void stopServer() {
-        testServer.ifPresent(testServer -> testServer.server.shutdown());
+        testServer.ifPresent(TestServer::shutdown);
         testServer = Optional.empty();
         urlTemplate = Optional.empty();
     }

--- a/src/test/java/io/divolte/server/ProxyAdjacentPeerAddressHandlerTest.java
+++ b/src/test/java/io/divolte/server/ProxyAdjacentPeerAddressHandlerTest.java
@@ -109,6 +109,6 @@ public class ProxyAdjacentPeerAddressHandlerTest {
 
     @After
     public void tearDown() {
-        server.server.shutdown();
+        server.shutdown();
     }
 }

--- a/src/test/java/io/divolte/server/RequestChecksumTest.java
+++ b/src/test/java/io/divolte/server/RequestChecksumTest.java
@@ -184,7 +184,7 @@ public class RequestChecksumTest {
         final TestServer oldServer = this.server;
         if (oldServer != newServer) {
             if (null != oldServer) {
-                oldServer.server.shutdown();
+                oldServer.shutdown();
             }
             this.server = newServer;
         }

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -22,6 +22,7 @@ import io.divolte.server.ServerTestUtils.EventPayload;
 import io.divolte.server.config.BrowserSourceConfiguration;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -309,5 +310,39 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         final DivolteEvent eventData = payload.event;
 
         assertEquals(Optional.of("pageView"), eventData.eventType);
+    }
+
+    @Test
+    public void shouldFlushEventsBeforeClickOut() throws Exception {
+        doSetUp();
+        Preconditions.checkState(null != server && null != driver);
+        gotoPage(EVENT_COMMIT);
+        assertEquals(Optional.of("pageView"), server.waitForEvent().event.eventType);
+
+        // Record the current page URL, so that later we can check we navigated away.
+        final String initialPageUrl = driver.getCurrentUrl();
+
+        // Locate the link to click on, and click it.
+        logger.info("Clicking link that will trigger events");
+        driver.findElement(By.id("clickout")).click();
+
+        // At this point 10 events should arrive, after which the browser navigates
+        // to the basic page.
+        for (int i = 0; i < 10; ++i) {
+            final EventPayload payload = server.waitForEvent();
+            final DivolteEvent eventData = payload.event;
+            assertEquals("Unexpected event type for event #" + i,
+                         Optional.of("clickOutEvent"),
+                         eventData.eventType);
+            assertEquals("Event index parameter incorrect for event #" + i,
+                         Optional.of(i),
+                         eventData.eventParametersProducer.get().map(jsonNode -> jsonNode.get("i").asInt()));
+        }
+        logger.info("Triggered events have all arrived.");
+
+        // Check that the browser did navigate to a new page. (It will also generate a page-view.)
+        final WebDriverWait wait = new WebDriverWait(driver, 30);
+        wait.until(driver -> !driver.getCurrentUrl().equals(initialPageUrl));
+        assertEquals(Optional.of("pageView"), server.waitForEvent().event.eventType);
     }
 }

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.divolte.server.ServerTestUtils.EventPayload;
 import io.divolte.server.config.BrowserSourceConfiguration;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.WebDriverWait;

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import io.divolte.server.ServerTestUtils.EventPayload;
 import io.divolte.server.config.BrowserSourceConfiguration;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -320,6 +321,29 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         final DivolteEvent eventData = payload.event;
 
         assertEquals(Optional.of("pageView"), eventData.eventType);
+    }
+
+    @Test
+    public void shouldAdvanceToNextEventOnTimeout() throws Exception {
+        doSetUp("selenium-test-slow-server.conf");
+        Preconditions.checkState(null != server && null != driver);
+        gotoPage(BASIC);
+        // No page-view events.
+
+        // Emit two events.
+        logger.info("Clicking link that will trigger 2 slow events");
+        driver.findElement(By.id("deliver2events")).click();
+        /*
+         * The server has been configured to delay responses by 15 seconds.
+         * The JavaScript should time them out quickly.
+         * This means both events should arrive within the time here,
+         * instead of waiting for the delayed responses.
+         */
+        logger.info("Waiting for first event");
+        server.waitForEvent();
+        logger.info("First event received; waiting for second event.");
+        server.waitForEvent();
+        logger.info("Second event received.");
     }
 
     @Test

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -363,8 +363,7 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         // At this point 10 events should arrive, after which the browser navigates
         // to the basic page.
         for (int i = 0; i < 10; ++i) {
-            final EventPayload payload = server.waitForEvent();
-            final DivolteEvent eventData = payload.event;
+            final DivolteEvent eventData = server.waitForEvent().event;
             assertEquals("Unexpected event type for event #" + i,
                          Optional.of("clickOutEvent"),
                          eventData.eventType);

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -378,4 +378,21 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         wait.until(driver -> !driver.getCurrentUrl().equals(initialPageUrl));
         assertEquals(Optional.of("pageView"), server.waitForEvent().event.eventType);
     }
+
+    @Test
+    public void shouldInvokeFlushCallbackImmediatelyIfNoEventsPending() throws Exception {
+        doSetUp();
+        Preconditions.checkState(null != server && null != driver);
+        gotoPage(EVENT_COMMIT);
+        assertEquals(Optional.of("pageView"), server.waitForEvent().event.eventType);
+
+        // Hit the 'flush' link, and wait for the event.
+        driver.findElement(By.id("flushdirect")).click();
+
+        // The event contains information about whether the callback was invoked immediately or not.
+        final DivolteEvent event = server.waitForEvent().event;
+        assertEquals(Optional.of("firstFlush"), event.eventType);
+        assertEquals(Optional.of(true),
+                     event.eventParametersProducer.get().map(jsonNode -> jsonNode.get("callbackWasImmediate").asBoolean()));
+    }
 }

--- a/src/test/java/io/divolte/server/SeleniumTestBase.java
+++ b/src/test/java/io/divolte/server/SeleniumTestBase.java
@@ -112,7 +112,7 @@ public abstract class SeleniumTestBase {
                     driver = null;
                 }
                 if (null != server) {
-                    server.server.shutdown();
+                    server.shutdown();
                     server = null;
                 }
                 testResultHook = Optional.empty();

--- a/src/test/java/io/divolte/server/SeleniumTestBase.java
+++ b/src/test/java/io/divolte/server/SeleniumTestBase.java
@@ -179,7 +179,8 @@ public abstract class SeleniumTestBase {
             BASIC_COPY("test-basic-page-copy"),
             PAGE_VIEW_SUPPLIED("test-basic-page-provided-pv-id"),
             CUSTOM_JAVASCRIPT_NAME("test-custom-javascript-name"),
-            CUSTOM_PAGE_VIEW("test-custom-page-view");
+            CUSTOM_PAGE_VIEW("test-custom-page-view"),
+            EVENT_COMMIT("test-event-commit");
 
             private final String resourceName;
 

--- a/src/test/java/io/divolte/server/ServerPingTest.java
+++ b/src/test/java/io/divolte/server/ServerPingTest.java
@@ -62,7 +62,7 @@ public class ServerPingTest {
     @After
     public void tearDown() {
         if (null != testServer) {
-            testServer.server.shutdown();
+            testServer.shutdown();
             testServer = null;
         }
     }

--- a/src/test/java/io/divolte/server/ServerSinkSourceConfigurationTest.java
+++ b/src/test/java/io/divolte/server/ServerSinkSourceConfigurationTest.java
@@ -85,13 +85,13 @@ public class ServerSinkSourceConfigurationTest {
     }
 
     private void startServer(final Supplier<TestServer> supplier) {
-        stopServer();
+        stopServer(false);
         testServer = supplier.get();
     }
 
-    public void stopServer() {
+    public void stopServer(final boolean waitForShutdown) {
         if (null != testServer) {
-            testServer.server.shutdown();
+            testServer.shutdown(waitForShutdown);
             testServer = null;
         }
     }
@@ -215,7 +215,7 @@ public class ServerSinkSourceConfigurationTest {
         request();
         testServer.waitForEvent();
         // Stopping the server flushes the HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check the number of events that turned up in new files in /tmp.
         assertEquals("Wrong number of new events logged to /tmp",
                      1, avroFileLocator.listNewRecords().count());
@@ -235,7 +235,7 @@ public class ServerSinkSourceConfigurationTest {
         request();
         testServer.waitForEvent();
         // Stopping the server flushes any HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check:
         //   - The default location (/tmp) shouldn't have anything new.
         //   - Our explicit location should have a single record.
@@ -263,7 +263,7 @@ public class ServerSinkSourceConfigurationTest {
         request();
         testServer.waitForEvent();
         // Stopping the server flushes any HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check:
         //   - The default location (/tmp) shouldn't have anything new.
         //   - Our locations should both have a single record.
@@ -296,7 +296,7 @@ public class ServerSinkSourceConfigurationTest {
         testServer.waitForEvent();
         testServer.waitForEvent();
         // Stopping the server flushes any HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check:
         //   - One source should have a single event.
         //   - The other should have a two events.
@@ -324,7 +324,7 @@ public class ServerSinkSourceConfigurationTest {
         testServer.waitForEvent();
         testServer.waitForEvent();
         // Stopping the server flushes any HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check:
         //   - Both sinks should have a single event.
         assertEquals("Wrong number of new events logged in first location",
@@ -348,7 +348,7 @@ public class ServerSinkSourceConfigurationTest {
         testServer.waitForEvent();
         testServer.waitForEvent();
         // Stopping the server flushes any HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check:
         //   - The single location should have received both events.
         assertEquals("Wrong number of new events logged",
@@ -392,7 +392,7 @@ public class ServerSinkSourceConfigurationTest {
         request("/source-4");
         testServer.waitForEvent();
         // Stopping the server flushes any HDFS files.
-        stopServer();
+        stopServer(true);
         // Now we can check:
         //   - Each sink should have a specific number of events in it.
         assertEquals("Wrong number of new events logged in first location",
@@ -407,7 +407,7 @@ public class ServerSinkSourceConfigurationTest {
 
     @After
     public void tearDown() throws IOException {
-        stopServer();
+        stopServer(false);
         cleanupTempDirectories();
     }
 

--- a/src/test/java/io/divolte/server/ServerSinkSourceConfigurationTest.java
+++ b/src/test/java/io/divolte/server/ServerSinkSourceConfigurationTest.java
@@ -89,20 +89,20 @@ public class ServerSinkSourceConfigurationTest {
         testServer = supplier.get();
     }
 
-    public void stopServer(final boolean waitForShutdown) {
+    private void stopServer(final boolean waitForShutdown) {
         if (null != testServer) {
             testServer.shutdown(waitForShutdown);
             testServer = null;
         }
     }
 
-    public Path createTempDirectory() throws IOException {
+    private Path createTempDirectory() throws IOException {
         final Path newTempDirectory = Files.createTempDirectory("divolte-test");
         tempDirectories.add(newTempDirectory);
         return newTempDirectory;
     }
 
-    public void cleanupTempDirectories() {
+    private void cleanupTempDirectories() {
         tempDirectories.forEach(ServerSinkSourceConfigurationTest::deleteRecursively);
         tempDirectories.clear();
     }

--- a/src/test/java/io/divolte/server/ServerTestUtils.java
+++ b/src/test/java/io/divolte/server/ServerTestUtils.java
@@ -102,7 +102,7 @@ public final class ServerTestUtils {
         final Config config;
         final String host;
         final int port;
-        final Server server;
+        private final Server server;
         final BlockingQueue<EventPayload> events;
 
         public TestServer() {
@@ -161,6 +161,20 @@ public final class ServerTestUtils {
 
         public boolean eventsRemaining() {
             return !events.isEmpty();
+        }
+
+        public void shutdown() {
+            shutdown(false);
+        }
+
+        public void shutdown(final boolean waitForShutdown) {
+            // The server can take a little while to shut down, so we do this asynchronously if possible.
+            // (This is harmless: new servers will listen on a different port.)
+            if (waitForShutdown) {
+                server.shutdown();
+            } else {
+                new Thread(server::shutdown).start();
+            }
         }
     }
 }

--- a/src/test/java/io/divolte/server/ServerTestUtils.java
+++ b/src/test/java/io/divolte/server/ServerTestUtils.java
@@ -156,7 +156,12 @@ public final class ServerTestUtils {
 
         public EventPayload waitForEvent() throws InterruptedException {
             // SauceLabs can take quite a while to fire up everything.
-            return Optional.ofNullable(events.poll(10, TimeUnit.SECONDS)).orElseThrow(() -> new RuntimeException("Timed out while waiting for server side event to occur."));
+            return waitForEvent(10, TimeUnit.SECONDS);
+        }
+
+        public EventPayload waitForEvent(final long timeout, final TimeUnit unit) throws InterruptedException {
+            return Optional.ofNullable(events.poll(timeout, unit))
+                           .orElseThrow(() -> new RuntimeException("Timed out while waiting for server side event to occur."));
         }
 
         public boolean eventsRemaining() {

--- a/src/test/java/io/divolte/server/ShortTermDuplicateMemoryTest.java
+++ b/src/test/java/io/divolte/server/ShortTermDuplicateMemoryTest.java
@@ -142,6 +142,6 @@ public class ShortTermDuplicateMemoryTest {
 
     @After
     public void tearDown() {
-        server.server.shutdown();
+        server.shutdown();
     }
 }

--- a/src/test/resources/selenium-test-slow-server.conf
+++ b/src/test/resources/selenium-test-slow-server.conf
@@ -1,0 +1,23 @@
+//
+// Copyright 2017 GoDataDriven B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Disable automatic default pageView event
+divolte.sources.browser {
+  type = browser
+  // Event responses will take this long.
+  http_response_delay = 15s
+  javascript.auto_page_view_event = false
+}

--- a/src/test/resources/static/quirks/test-basic-page.html
+++ b/src/test/resources/static/quirks/test-basic-page.html
@@ -58,5 +58,7 @@
                                    q: {}
                                  }
                                  )">Click me to fire an event!</div>
+    <div id="deliver2events"
+         onclick="divolte.signal('firstEvent'); divolte.signal('secondEvent')">Click me to fire two events!</div>
   </body>
 </html>

--- a/src/test/resources/static/quirks/test-event-commit.html
+++ b/src/test/resources/static/quirks/test-event-commit.html
@@ -28,10 +28,9 @@
     <!-- Not deferred, as we need the module right away. -->
     <script src="/divolte.js" defer async></script>
     <script>
-      var signalThenClick = function(link) {
+      var signalThenClick = function(link, eventCount, optionalTimeoutMilliseconds) {
           // Fire off some events.
-          // (10 is enough to create a backlog.)
-          for (var i = 0; i < 10; ++i) {
+          for (var i = 0; i < eventCount; ++i) {
               divolte.signal('clickOutEvent', { i: i });
           }
           // Block until they're flushed, then proceed to the link destination.
@@ -44,7 +43,7 @@
                   window.location = linkDestination;
               }
               navigationSentinel = true;
-          });
+          }, optionalTimeoutMilliseconds);
           var proceedWithClick = navigationSentinel;
           navigationSentinel = true;
           return proceedWithClick;
@@ -61,7 +60,9 @@
           callbackWasImmediate = false;
       }
     </script>
-    <a id="clickout" href="test-basic-page.html" onclick="return signalThenClick(this);">This link goes to a new page.</a>
+    <a id="clickout" href="test-basic-page.html" onclick="return signalThenClick(this, 10);">This link goes to a new page.</a>
+    <!-- These numbers are tuned to allow all our automated test clients to get some events started before the timeout, but not all. -->
+    <a id="quickout" href="test-basic-page.html" onclick="return signalThenClick(this, 1000, 500);">This link also goes to a new page.</a>
     <div id="flushdirect" onclick="return signalTestingDirectCallback();">This isn't a link, but clicking does stuff.</div>
   </body>
 </html>

--- a/src/test/resources/static/quirks/test-event-commit.html
+++ b/src/test/resources/static/quirks/test-event-commit.html
@@ -1,0 +1,55 @@
+<!--
+  ~ Copyright 2017 GoDataDriven B.V.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DVT</title>
+
+    <!-- Suppress favicon requests. -->
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  </head>
+  <body>
+    <!-- Not deferred, as we need the module right away. -->
+    <script src="/divolte.js" defer async></script>
+    <script>
+      var signalThenClick = function(link) {
+          // Fire off some events.
+          // (10 is enough to create a backlog.)
+          for (var i = 0; i < 10; ++i) {
+              divolte.signal('clickOutEvent', { i: i });
+          }
+          // Block until they're flushed, then proceed to the link destination.
+          // Note: we detect here if we need to defer.
+          var linkDestination = link.getAttribute("href");
+          // Sentinel is true when the _next_ checker needs to handle navigation.
+          var navigationSentinel = false;
+          divolte.whenCommitted(function () {
+              if (navigationSentinel) {
+                  window.location = linkDestination;
+              }
+              navigationSentinel = true;
+          });
+          var proceedWithClick = navigationSentinel;
+          navigationSentinel = true;
+          return proceedWithClick;
+      };
+    </script>
+    <a id="clickout" href="test-basic-page.html" onclick="return signalThenClick(this);">This link goes to a new page.</a>
+  </body>
+</html>

--- a/src/test/resources/static/quirks/test-event-commit.html
+++ b/src/test/resources/static/quirks/test-event-commit.html
@@ -49,7 +49,19 @@
           navigationSentinel = true;
           return proceedWithClick;
       };
+      var signalTestingDirectCallback = function() {
+          // There aren't any events pending.
+          var callbackWasImmediate = true;
+          divolte.whenCommitted(function () {
+              // If invoked directly, the parameter will be true.
+              // If deferred, it will be false.
+              // (Javascript doesn't allow preemption.)
+              divolte.signal("firstFlush", { callbackWasImmediate: callbackWasImmediate });
+          });
+          callbackWasImmediate = false;
+      }
     </script>
     <a id="clickout" href="test-basic-page.html" onclick="return signalThenClick(this);">This link goes to a new page.</a>
+    <div id="flushdirect" onclick="return signalTestingDirectCallback();">This isn't a link, but clicking does stuff.</div>
   </body>
 </html>

--- a/src/test/resources/static/strict/test-basic-page.html
+++ b/src/test/resources/static/strict/test-basic-page.html
@@ -59,5 +59,7 @@
                                    q: {}
                                  }
                                  )">Click me to fire an event!</div>
+    <div id="deliver2events"
+         onclick="divolte.signal('firstEvent'); divolte.signal('secondEvent')">Click me to fire two events!</div>
   </body>
 </html>

--- a/src/test/resources/static/strict/test-event-commit.html
+++ b/src/test/resources/static/strict/test-event-commit.html
@@ -29,10 +29,9 @@
     <!-- Not deferred, as we need the module right away. -->
     <script src="/divolte.js" defer async></script>
     <script>
-      var signalThenNavigate = function(link) {
+      var signalThenClick = function(link, eventCount, optionalTimeoutMilliseconds) {
           // Fire off some events.
-          // (10 is enough to create a backlog.)
-          for (var i = 0; i < 10; ++i) {
+          for (var i = 0; i < eventCount; ++i) {
               divolte.signal('clickOutEvent', { i: i });
           }
           // Block until they're flushed, then proceed to the link destination.
@@ -45,7 +44,7 @@
                   window.location = linkDestination;
               }
               navigationSentinel = true;
-          });
+          }, optionalTimeoutMilliseconds);
           var proceedWithClick = navigationSentinel;
           navigationSentinel = true;
           return proceedWithClick;
@@ -62,7 +61,9 @@
           callbackWasImmediate = false;
       }
     </script>
-    <a id="clickout" href="test-basic-page.html" onclick="return signalThenNavigate(this);">This link goes to a new page.</a>
+    <a id="clickout" href="test-basic-page.html" onclick="return signalThenClick(this, 10);">This link goes to a new page.</a>
+    <!-- These numbers are tuned to allow all our automated test clients to get some events started before the timeout, but not all. -->
+    <a id="quickout" href="test-basic-page.html" onclick="return signalThenClick(this, 1000, 500);">This link also goes to a new page.</a>
     <div id="flushdirect" onclick="return signalTestingDirectCallback();">This isn't a link, but clicking does stuff.</div>
   </body>
 </html>

--- a/src/test/resources/static/strict/test-event-commit.html
+++ b/src/test/resources/static/strict/test-event-commit.html
@@ -50,7 +50,19 @@
           navigationSentinel = true;
           return proceedWithClick;
       };
+      var signalTestingDirectCallback = function() {
+          // There aren't any events pending.
+          var callbackWasImmediate = true;
+          divolte.whenCommitted(function () {
+              // If invoked directly, the parameter will be true.
+              // If deferred, it will be false.
+              // (Javascript doesn't allow preemption.)
+              divolte.signal("firstFlush", { callbackWasImmediate: callbackWasImmediate });
+          });
+          callbackWasImmediate = false;
+      }
     </script>
     <a id="clickout" href="test-basic-page.html" onclick="return signalThenNavigate(this);">This link goes to a new page.</a>
+    <div id="flushdirect" onclick="return signalTestingDirectCallback();">This isn't a link, but clicking does stuff.</div>
   </body>
 </html>

--- a/src/test/resources/static/strict/test-event-commit.html
+++ b/src/test/resources/static/strict/test-event-commit.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright 2017 GoDataDriven B.V.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DVT</title>
+
+    <!-- Suppress favicon requests. -->
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  </head>
+  <body>
+    <!-- Not deferred, as we need the module right away. -->
+    <script src="/divolte.js" defer async></script>
+    <script>
+      var signalThenNavigate = function(link) {
+          // Fire off some events.
+          // (10 is enough to create a backlog.)
+          for (var i = 0; i < 10; ++i) {
+              divolte.signal('clickOutEvent', { i: i });
+          }
+          // Block until they're flushed, then proceed to the link destination.
+          // Note: we detect here if we need to defer.
+          var linkDestination = link.getAttribute("href");
+          // Sentinel is true when the _next_ checker needs to handle navigation.
+          var navigationSentinel = false;
+          divolte.whenCommitted(function () {
+              if (navigationSentinel) {
+                  window.location = linkDestination;
+              }
+              navigationSentinel = true;
+          });
+          var proceedWithClick = navigationSentinel;
+          navigationSentinel = true;
+          return proceedWithClick;
+      };
+    </script>
+    <a id="clickout" href="test-basic-page.html" onclick="return signalThenNavigate(this);">This link goes to a new page.</a>
+  </body>
+</html>


### PR DESCRIPTION
This pull request includes:

 - A major performance improvement for automated tests.
   A major component of the total test time was spent waiting for the server to shutdown at the end of a test. This typically takes half a second because when idle shutdown can only occur when the internal processing pools issue a heartbeat, and the heartbeat interval is a second. Where possible we now shut the server down in the background, allowing the next test to start immediately instead of having to wait.
 - For browser sources the timeout after which events being delivered are considered 'abandoned' is now configurable. Instead of being hard-coded to a second it defaults to 750 milliseconds.
 - Browser sources now support a `whenCommitted` call that invokes a supplied callback when pending events have been delivered to the server (or timed out). This resolves issue #160.