### PR TITLE
Fix some bugs pertaining to the page-view lifecycle

### DIFF
--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -22,6 +22,8 @@ import io.divolte.server.ServerTestUtils.EventPayload;
 import io.divolte.server.config.BrowserSourceConfiguration;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +105,26 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         };
         final int numberOfUniquePageViewIDs = uniquePageViewIdsForSeriesOfActions(actions);
         assertEquals(actions.length, numberOfUniquePageViewIDs);
+    }
+
+    @Test
+    public void shouldSignalWhenLateLoaded() throws Exception {
+        doSetUp();
+        Preconditions.checkState(null != driver && null != server);
+
+        // Go to the page but don't load Divolte immediately.
+        gotoPage(PAGE_VIEW_DEFERRED_LOAD, false);
+        final WebDriverWait wait = new WebDriverWait(driver, 30);
+        final WebElement loadButton = wait.until(ExpectedConditions.presenceOfElementLocated(By.id("load_divolte")));
+
+        logger.info("Triggering deferred loading of Divolte");
+        loadButton.click();
+
+        // Wait for the page-view event to arrive.
+        final EventPayload payload = server.waitForEvent();
+        final DivolteEvent eventData = payload.event;
+
+        assertEquals(Optional.of("pageView"), eventData.eventType);
     }
 
     @Test

--- a/src/test/java/io/divolte/server/SeleniumTestBase.java
+++ b/src/test/java/io/divolte/server/SeleniumTestBase.java
@@ -207,6 +207,7 @@ public abstract class SeleniumTestBase {
             BASIC("test-basic-page"),
             BASIC_COPY("test-basic-page-copy"),
             PAGE_VIEW_SUPPLIED("test-basic-page-provided-pv-id"),
+            PAGE_VIEW_DEFERRED_LOAD("test-page-view-deferred-load"),
             CUSTOM_JAVASCRIPT_NAME("test-custom-javascript-name"),
             CUSTOM_PAGE_VIEW("test-custom-page-view"),
             EVENT_COMMIT("test-event-commit");
@@ -226,11 +227,16 @@ public abstract class SeleniumTestBase {
     }
 
     protected String gotoPage(final TestPages page) {
+        return gotoPage(page, true);
+    }
+
+    protected String gotoPage(final TestPages page, final boolean waitForDivolte) {
         Preconditions.checkState(null != driver);
         String url = urlOf(page);
         driver.navigate().to(url);
-        // All test pages load Divolte.
-        waitDivolteLoaded();
+        if (waitForDivolte) {
+            waitDivolteLoaded();
+        }
         return url;
     }
 

--- a/src/test/resources/static/quirks/test-page-view-deferred-load.html
+++ b/src/test/resources/static/quirks/test-page-view-deferred-load.html
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2017 GoDataDriven B.V.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/liceonses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DVT</title>
+
+    <!-- Suppress favicon requests. -->
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+</head>
+<!--
+  == Defer loading Divolte until after the page is 'up'.
+  == We do this by embedding a button whose click-handler will load Divolte.
+  == The test will hit the button to trigger the load.
+  -->
+<body>
+<script>
+    function deferredLoad() {
+        var script = document.createElement('script');
+        script.src = "/divolte.js";
+        var head = document.getElementsByTagName('head')[0];
+        head.appendChild(script);
+    }
+</script>
+<div id="load_divolte" onclick="deferredLoad()">Click me to load Divolte!</div>
+</body>
+</html>

--- a/src/test/resources/static/strict/test-page-view-deferred-load.html
+++ b/src/test/resources/static/strict/test-page-view-deferred-load.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright 2017 GoDataDriven B.V.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/liceonses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DVT</title>
+
+    <!-- Suppress favicon requests. -->
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  </head>
+  <!--
+    == Defer loading Divolte until after the page is 'up'.
+    == We do this by embedding a button whose click-handler will load Divolte.
+    == The test will hit the button to trigger the load.
+    -->
+  <body>
+    <script>
+      function deferredLoad() {
+        var script = document.createElement('script');
+        script.src = "/divolte.js";
+        var head = document.getElementsByTagName('head')[0];
+        head.appendChild(script);
+      }
+    </script>
+    <div id="load_divolte" onclick="deferredLoad()">Click me to load Divolte!</div>
+  </body>
+</html>


### PR DESCRIPTION
This pull request reverts most of the logic for triggering the start of a page-view to be similar to how it worked prior to the 0.5 release, resolving #164.

Further to this:
 - Late-loading is now tested as part of the automated test suite.
 - We now ensure that `signal()` will work even if the page-view hasn't started.
 - There's now Internal documentation for the page-view lifecycle and implementation.
