### PR TITLE
Selenium depends on version 0.23 of guava this conflicts the configur…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     compile group: 'io.divolte', name: 'divolte-schema', version: version
     compile group: 'io.undertow', name: 'undertow-core', version: '1.4.16.Final'
     compile group: 'com.typesafe', name: 'config', version: '1.3.1'
-    compile group: 'com.google.guava', name: 'guava', version: '22.0'
+    compile group: 'com.google.guava', name: 'guava', version: '23.0'
     compile group: 'org.apache.avro', name: 'avro', version: avroVersion
 
     /*


### PR DESCRIPTION
4th of august a new release of guava (0.23) broke the build. Selenium is depending on the new version that was causing a compile error:
`SeleniumTestBase.java:254: error: method until in class FluentWait<T> cannot be applied to given types;
        wait.until(DIVOLTE_LOADED);
            ^
  required: Function<? super WebDriver,V>
  found: ExpectedCondition<Boolean>
  reason: cannot infer type-variable(s) V
    (argument mismatch; ExpectedCondition<Boolean> cannot be converted to Function<? super WebDriver,V>)
  where V,T are type-variables:
    V extends Object declared in method <V>until(Function<? super T,V>)
    T extends Object declared in class FluentWait`

This PR fixes this by using 0.23 in our project.