### PR TITLE
fix classpath for the RPM version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     //   - The client from 0.10.2.0 onwards supports brokers from 0.10.0.0 onwards.
     // Note: we refer to versioned producer documentation in our documentation.
     compile group: 'org.apache.kafka', name:'kafka-clients', version: '0.10.2.1'
-    compile group: 'com.google.javascript', name:'closure-compiler', version:'v20170521'
+    compile group: 'com.google.javascript', name:'closure-compiler-unshaded', version:'v20170806'
     compile group: 'org.codehaus.groovy', name:'groovy', version: '2.4.11', classifier: 'indy'
     compile group: 'net.sf.jopt-simple', name:'jopt-simple', version: '5.0.3'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'

--- a/src/scripts/divolte-collector
+++ b/src/scripts/divolte-collector
@@ -44,7 +44,9 @@ fi
 
 # add libs to CLASSPATH
 join() { local IFS="$1"; shift; echo "$*"; }
-CLASSPATH=$(join ":" $APP_HOME/lib/*.jar)
+# there are multiple versions of guava on the classpath. Most important is avro that bundles guava in the jar.
+# we want to have guava in front of these dependencies.
+CLASSPATH=$(echo $APP_HOME/lib/guava*.jar):$(join ":" $APP_HOME/lib/*.jar)
 
 # add any present HADOOP_CONF_DIR
 [ -n "$HADOOP_CONF_DIR" ] && CLASSPATH="$HADOOP_CONF_DIR:$CLASSPATH"

--- a/src/scripts/divolte-collector
+++ b/src/scripts/divolte-collector
@@ -44,9 +44,7 @@ fi
 
 # add libs to CLASSPATH
 join() { local IFS="$1"; shift; echo "$*"; }
-# there are multiple versions of guava on the classpath. Most important is avro that bundles guava in the jar.
-# we want to have guava in front of these dependencies.
-CLASSPATH=$(echo $APP_HOME/lib/guava*.jar):$(join ":" $APP_HOME/lib/*.jar)
+CLASSPATH=$(join ":" $APP_HOME/lib/*.jar)
 
 # add any present HADOOP_CONF_DIR
 [ -n "$HADOOP_CONF_DIR" ] && CLASSPATH="$HADOOP_CONF_DIR:$CLASSPATH"


### PR DESCRIPTION
The current 0.6 version of the RPM ships a broken startscript. there is a version conflict on a guava class. This PR fixes the issue.