### PR TITLE
Rocket loader js friendly

### DIFF
--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -84,7 +84,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
      * our script name, as configured by the globally defined SCRIPT_NAME
      * value.
      */
-    var myElement = document['currentScript'];
+    var myElement = document['currentScript'] || undefined;
     var url;
     if ('undefined' === typeof myElement) {
       var regexEscape = function (s) {
@@ -93,7 +93,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
       var scriptElements = document.getElementsByTagName('script');
       var scriptPattern = new RegExp("^(:?.*\/)?" + regexEscape(SCRIPT_NAME) + "(:?[?#].*)?$");
       for (var i = scriptElements.length - 1; i >= 0; --i) {
-        var scriptElement = scriptElements.item(i);
+        var scriptElement = scriptElements[i];
         var scriptUrl = scriptElement.src;
         if (scriptPattern.test(scriptUrl)) {
           if ('undefined' === typeof url) {
@@ -131,7 +131,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
    * @returns {?(HTMLElement|Node)}
    */
   var bodyElement = function() {
-    return document.body || document.getElementsByTagName('body').item(0);
+    return document.body || document.getElementsByTagName('body')[0];
   };
 
   /* Some current browser features that we send to Divolte. */


### PR DESCRIPTION
Rocket loader [1] is a general purpose asynchronous Javascript loader that is used by Cloudflare to speed up the page load. Rocket loader will replace some of the native javascript functions with their own optimised functions and that cause issues with divolte.js

Issues caused by rocket loader:

1 - Access DOM array with [index] instead of item(index)

In this case, the HTML DOM item function is not part of the Rocket Loader function wrappers, therefore we need to access the element with [index] instead of item(index)

<table>
<tr>
<th>Rocket loader site</th>
</tr>
<td>
<img width=“400” alt="after" src="https://user-images.githubusercontent.com/794601/33643671-8eb47a30-da7b-11e7-8f01-0011e6b3801e.png">
</td>
</table>
​
<table>
<tr>
<th>Normal site</th>
</tr>
<td>
<img width=“400” alt="after" src="https://user-images.githubusercontent.com/794601/33643672-8ee66f54-da7b-11e7-9448-71dce18be6fb.png">
</td>
</table>



2 - Rocket loader evaluates `document.currentScript` to null.

This will fail in https://github.com/divolte/divolte-collector/blob/master/src/main/resources/divolte.js#L87-L108 , because

`typeof null === object`


[1] https://support.cloudflare.com/hc/en-us/articles/200168056-What-does-Rocket-Loader-do-


please advise