### PR TITLE
Lower the log importance of the Improper request

### DIFF
--- a/src/main/java/io/divolte/server/JsonEventHandler.java
+++ b/src/main/java/io/divolte/server/JsonEventHandler.java
@@ -83,7 +83,7 @@ public class JsonEventHandler implements HttpHandler {
             } catch (final IncompleteRequestException e) {
                 // Improper request, could be anything.
                 exchange.setStatusCode(StatusCodes.BAD_REQUEST);
-                logger.warn("Improper request received from {}.",
+                logger.info("Improper request received from {}.",
                             Optional.ofNullable(exchange.getSourceAddress())
                                     .map(InetSocketAddress::getHostString)
                                     .orElse("<UNKNOWN HOST>"));


### PR DESCRIPTION
Hi all,

We would like to lower the importance of the log line when receiving a malformed json document. We get these requests a lot and it fills up the logs rather quickly.

Cheers, Fokko