### PR TITLE
[WIP] Make sure that Divolte has a graceful shutdown

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -102,3 +102,15 @@ When using `nginx <http://nginx.org/>`_ as a reverse proxy and load balancer in 
 Kafka Connect
 =============
 When deploying in conjunction with Kafka Connect, the Avro schemas need to be pre-registered with the `Schema Registry <https://docs.confluent.io/3.3.0/schema-registry/docs>`_. Mappings that produce records for a Kafka sink operating in ``confluent`` mode need have their ``confluent_id`` property configured with the identifier of the schema in the registry. (This identifier is normally a simple integer.)
+
+Service endpoints
+=================
+
+To support rolling updates and scaling without losing data, Divolte exposes an endpoint that allows save shutdown of the docker container. Currently the `/health` endpoint is tested on Kubernetes. The main issue with Kubernetes is, even it has send a signal to stop the container, the container will remain in the pool of the load balancer. This will cause the divolte container to receive new connections, which is not something that we want when initializing a graceful shutdown procedure. Instead Divolte should clear all the buffers by flushing them to persistent storage. The sequence:
+
+- Kubernetes sends a SIGTERM to Divolte to let it know that it wants to shutdown the container.
+- Making the container unhealthy by replying with HTTP 503 over the `/health` endpoint, which will cause the container to be removed from the pool of the load balancer.
+- The `divolte.global.server.shutdown_wait_period_mills` property should be at least twice the kubernetes liveness probe interval (10 seconds by default).
+- The container is removed from the loadbalancer pool and divolte will wait `divolte.global.server.shutdown_grace_period_mills` to handle and close the open connections.
+- Undertow will shut down, and all the sinks are flushed and closed.
+- If everything is not handled within 30 seconds (by default), kubernetes will kill the container and data might be lost forever :(

--- a/src/main/java/io/divolte/server/HealthHandler.java
+++ b/src/main/java/io/divolte/server/HealthHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.divolte.server;
+
+import java.nio.charset.StandardCharsets;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+
+/**
+ * Event handler for ping requests.
+ *
+ * Ping requests are immediately and always responded to with a "pong" text response.
+ */
+@ParametersAreNonnullByDefault
+final class HealthHandler implements HttpHandler {
+    private static final Logger logger = LoggerFactory.getLogger(Server.class);
+    private boolean shutdown;
+
+    public HealthHandler() {
+        // Prevent external instantiation.
+        shutdown = false;
+    }
+
+    public void shutdown() {
+        this.shutdown = true;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        logger.debug("Health check from {}", exchange.getSourceAddress().getHostString());
+        exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain; charset=utf-8");
+        if(shutdown) {
+            // If we started a shutdown, we want the health check to a 503 to let upstream
+            // know that we are shutting down and it should be removed from the pool
+            exchange.setStatusCode(HTTP_UNAVAILABLE);
+            exchange.getResponseSender().send("SHUTDOWN", StandardCharsets.UTF_8);
+
+            logger.info("Return 503 on health check to indicate shutdown");
+        } else {
+            exchange.getResponseSender().send("OK", StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/main/java/io/divolte/server/config/ServerConfiguration.java
+++ b/src/main/java/io/divolte/server/config/ServerConfiguration.java
@@ -32,18 +32,21 @@ public final class ServerConfiguration {
     public final boolean useXForwardedFor;
     public final boolean serveStaticResources;
     public final boolean debugRequests;
+    public final int shutdownGracePeriodMills;
 
     @JsonCreator
     ServerConfiguration(final Optional<String> host,
                         final int port,
                         @JsonProperty("use_x_forwarded_for") final boolean useXForwardedFor,
                         final boolean serveStaticResources,
-                        final boolean debugRequests) {
+                        final boolean debugRequests,
+                        final int shutdownGracePeriodMills) {
         this.host = Objects.requireNonNull(host);
         this.port = port;
         this.useXForwardedFor = useXForwardedFor;
         this.serveStaticResources = serveStaticResources;
         this.debugRequests = debugRequests;
+        this.shutdownGracePeriodMills = shutdownGracePeriodMills;
     }
 
     @Override
@@ -54,6 +57,7 @@ public final class ServerConfiguration {
                 .add("useXForwardedFor", useXForwardedFor)
                 .add("serverStaticResources", serveStaticResources)
                 .add("debugRequests", debugRequests)
+                .add("shutdownGracePeriodMills", shutdownGracePeriodMills)
                 .toString();
     }
 }

--- a/src/main/java/io/divolte/server/config/ServerConfiguration.java
+++ b/src/main/java/io/divolte/server/config/ServerConfiguration.java
@@ -33,6 +33,7 @@ public final class ServerConfiguration {
     public final boolean serveStaticResources;
     public final boolean debugRequests;
     public final int shutdownGracePeriodMills;
+    public final int shutdownWaitPeriodMills;
 
     @JsonCreator
     ServerConfiguration(final Optional<String> host,
@@ -40,13 +41,15 @@ public final class ServerConfiguration {
                         @JsonProperty("use_x_forwarded_for") final boolean useXForwardedFor,
                         final boolean serveStaticResources,
                         final boolean debugRequests,
-                        final int shutdownGracePeriodMills) {
+                        final int shutdownGracePeriodMills,
+                        final int shutdownWaitPeriodMills) {
         this.host = Objects.requireNonNull(host);
         this.port = port;
         this.useXForwardedFor = useXForwardedFor;
         this.serveStaticResources = serveStaticResources;
         this.debugRequests = debugRequests;
         this.shutdownGracePeriodMills = shutdownGracePeriodMills;
+        this.shutdownWaitPeriodMills = shutdownWaitPeriodMills;
     }
 
     @Override
@@ -58,6 +61,7 @@ public final class ServerConfiguration {
                 .add("serverStaticResources", serveStaticResources)
                 .add("debugRequests", debugRequests)
                 .add("shutdownGracePeriodMills", shutdownGracePeriodMills)
+                .add("shutdownWaitPeriodMills", shutdownWaitPeriodMills)
                 .toString();
     }
 }

--- a/src/main/java/io/divolte/server/processing/ProcessingPool.java
+++ b/src/main/java/io/divolte/server/processing/ProcessingPool.java
@@ -97,6 +97,7 @@ public class ProcessingPool<T extends ItemProcessor<E>, E> {
             executorService.shutdown();
             executorService.awaitTermination(1, TimeUnit.HOURS);
         } catch (final InterruptedException e) {
+            logger.warn("Received an exception while stopping the executor service", e);
             Thread.currentThread().interrupt();
         }
     }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -54,6 +54,12 @@ divolte {
       // The default shutdown grace period in milliseconds
       // The time to wait to the existing connections to complete
       shutdown_grace_period_mills = 192500
+
+      // The default shutdown wait period in milliseconds
+      // After shutting down Undertow, the endpoints will return 503 to notify
+      // that the api is unavailble, we might want to wait a while to make sure
+      // the instance is removed from the load-balancer
+      shutdown_wait_period_mills = 0
     }
 
     mapper {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -50,6 +50,10 @@ divolte {
       // Whether requests (and their response) should be logged for debugging.
       // This is for testing purposes only; it should never be enabled in production.
       debug_requests = false
+
+      // The default shutdown grace period in milliseconds
+      // The time to wait to the existing connections to complete
+      shutdown_grace_period_mills = 192500
     }
 
     mapper {

--- a/src/test/java/io/divolte/server/ServerHealthTest.java
+++ b/src/test/java/io/divolte/server/ServerHealthTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.divolte.server;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteStreams;
+import com.typesafe.config.ConfigFactory;
+import io.divolte.server.ServerTestUtils.TestServer;
+import io.divolte.server.config.ValidatedConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static org.junit.Assert.assertEquals;
+
+@ParametersAreNonnullByDefault
+public class ServerHealthTest {
+
+    @Nullable
+    private TestServer testServer;
+
+    @Before
+    public void setup() {
+        testServer = new TestServer("reference-test-shutdown.conf");
+    }
+
+    @Test
+    public void shouldRespondToHealthCheck() throws IOException {
+        Preconditions.checkState(null != testServer);
+        final URL url = new URL(String.format("http://%s:%d/health", testServer.host, testServer.port));
+        final HttpURLConnection conn1 = (HttpURLConnection) url.openConnection();
+        try {
+            conn1.setRequestMethod("GET");
+            assertEquals(HTTP_OK, conn1.getResponseCode());
+            assertEquals("text/plain; charset=utf-8", conn1.getContentType());
+            final String body = new String(ByteStreams.toByteArray(conn1.getInputStream()), StandardCharsets.UTF_8);
+            assertEquals("OK", body);
+        } finally {
+            conn1.disconnect();
+        }
+
+        // Start the shutdown procedure
+        testServer.shutdown();
+
+        final HttpURLConnection conn2 = (HttpURLConnection) url.openConnection();
+        try {
+            conn2.setRequestMethod("GET");
+            assertEquals(HTTP_UNAVAILABLE, conn2.getResponseCode());
+            assertEquals("text/plain; charset=utf-8", conn2.getContentType());
+        } finally {
+            conn2.disconnect();
+        }
+    }
+
+    @After
+    public void tearDown() {
+        if (null != testServer) {
+            testServer = null;
+        }
+    }
+}

--- a/src/test/java/io/divolte/server/config/ValidatedConfigurationTest.java
+++ b/src/test/java/io/divolte/server/config/ValidatedConfigurationTest.java
@@ -165,9 +165,17 @@ public class ValidatedConfigurationTest {
 
     @Test
     public void shouldSetShutdownGracePeriodMills() {
-        final ValidatedConfiguration vc = new ValidatedConfiguration(() -> ConfigFactory.parseResources("reference-test.conf"));
+        final ValidatedConfiguration vc = new ValidatedConfiguration(() -> ConfigFactory.parseResources("reference-test-shutdown.conf"));
 
         assertTrue(vc.isValid());
         assertEquals(192500, vc.configuration().global.server.shutdownGracePeriodMills);
+    }
+
+    @Test
+    public void shouldSetShutdownWaitPeriodMills() {
+        final ValidatedConfiguration vc = new ValidatedConfiguration(() -> ConfigFactory.parseResources("reference-test-shutdown.conf"));
+
+        assertTrue(vc.isValid());
+        assertEquals(2200, vc.configuration().global.server.shutdownWaitPeriodMills);
     }
 }

--- a/src/test/java/io/divolte/server/config/ValidatedConfigurationTest.java
+++ b/src/test/java/io/divolte/server/config/ValidatedConfigurationTest.java
@@ -162,4 +162,12 @@ public class ValidatedConfigurationTest {
                 .startsWith("Property 'divolte.' Any sink can only use one confluent identifier. The following sinks have multiple mappings with different 'confluent_id' attributes: [kafka]..")
         );
     }
+
+    @Test
+    public void shouldSetShutdownGracePeriodMills() {
+        final ValidatedConfiguration vc = new ValidatedConfiguration(() -> ConfigFactory.parseResources("reference-test.conf"));
+
+        assertTrue(vc.isValid());
+        assertEquals(192500, vc.configuration().global.server.shutdownGracePeriodMills);
+    }
 }

--- a/src/test/resources/reference-test-shutdown.conf
+++ b/src/test/resources/reference-test-shutdown.conf
@@ -14,17 +14,20 @@
 // limitations under the License.
 //
 
-include classpath("reference.conf")
+include classpath("reference-test.conf")
 
 divolte {
   global {
-    mapper {
-      // For tests we generally want single-threaded processing with a small
-      // buffer.
-      buffer_size = 16
-      threads = 1
-    }
+    server {
+      // The default shutdown wait period in milliseconds
+      // After shutting down Undertow, the endpoints will return 503 to notify
+      // that the api is unavailble, we might want to wait a while to make sure
+      // the instance is removed from the load-balancer
+      shutdown_wait_period_mills = 2200
 
-    hdfs.enabled = false
+      // The default shutdown grace period in milliseconds
+      // The time to wait to the existing connections to complete
+      shutdown_grace_period_mills = 192500
+    }
   }
 }

--- a/src/test/resources/reference-test.conf
+++ b/src/test/resources/reference-test.conf
@@ -17,7 +17,15 @@
 include classpath("reference.conf")
 
 divolte {
+
   global {
+
+    server {
+      // The default shutdown grace period in milliseconds
+      // The time to wait to the existing connections to complete
+      shutdown_grace_period_mills = 192500
+    }
+
     mapper {
       // For tests we generally want single-threaded processing with a small
       // buffer.


### PR DESCRIPTION
When we want to run Divolte on top of k8s, we have to make sure that it implements a graceful shutdown. In case of rolling updates, and autoscaling, it has to send all the data to the sinks before shutting down.