### PR TITLE
WIP: Improve header extraction

### DIFF
--- a/docs/mapping_reference.rst
+++ b/docs/mapping_reference.rst
@@ -1637,9 +1637,17 @@ Complex value: :code:`ip2geo({optionalIP})`
     def ua = ip2geo()
 
     // If a load balancer sets custom headers for IP addresses, use like this
-    def ip = header('X-Custom-Header').first()
+    def ip = header('X-Forwarded-For').first()
     def myUa = ip2geo(ip)
 
+Also other functions are available depending on the array of IP's:
+
+  .. code-block:: groovy
+
+    // Returns the last item of the list
+    def ip = header('X-Forwarded-For').last()
+    // Returns the second last item
+    def ip = header('X-Forwarded-For').get(-2)
 
 :Sources:
 

--- a/src/test/java/io/divolte/server/DslRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/DslRecordMapperTest.java
@@ -279,11 +279,19 @@ public class DslRecordMapperTest {
     }
 
     @Test
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public void shouldSetCustomHeaders() throws IOException, InterruptedException {
         setupServer("header-mapping.groovy");
         final EventPayload event = request("http://www.example.com/");
+
+        assertEquals("192.168.0.1", event.record.get("headerArrayFirst"));
+        assertEquals("10.19.25.22", event.record.get("headerArrayLast"));
+        assertEquals("127.0.0.1", event.record.get("headerArraySecondLast"));
+
         assertEquals(Arrays.asList("first", "second", "last"), event.record.get("headerList"));
-        assertEquals("first", event.record.get("header"));
+        assertEquals("first", event.record.get("headerFirst"));
+        assertEquals("last", event.record.get("headerLast"));
+        assertEquals("second", event.record.get("headerSecondLast"));
         assertEquals("first,second,last", event.record.get("headers"));
     }
 
@@ -516,6 +524,7 @@ public class DslRecordMapperTest {
         final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.addRequestProperty("User-Agent", USER_AGENT);
         conn.addRequestProperty("Cookie", "custom_cookie=custom_cookie_value;");
+        conn.addRequestProperty("X-Divolte-Test-Array", "192.168.0.1, 127.0.0.1, 10.19.25.22");
         conn.addRequestProperty("X-Divolte-Test", "first");
         conn.addRequestProperty("X-Divolte-Test", "second");
         conn.addRequestProperty("X-Divolte-Test", "last");

--- a/src/test/resources/TestRecord.avsc
+++ b/src/test/resources/TestRecord.avsc
@@ -175,6 +175,13 @@
           ],
           "default": null
         },
+        { "name": "headerArrayFirst",                 "type": ["null","string"],  "default": null },
+        { "name": "headerArraySecondLast",            "type": ["null","string"],  "default": null },
+        { "name": "headerArrayLast",                  "type": ["null","string"],  "default": null },
+        { "name": "headerFirst",                      "type": ["null","string"],  "default": null },
+        { "name": "headerGet",                        "type": ["null","string"],  "default": null },
+        { "name": "headerLast",                       "type": ["null","string"],  "default": null },
+        { "name": "headerSecondLast",                 "type": ["null","string"],  "default": null },
         { "name": "header",                           "type": ["null","string"],  "default": null },
         { "name": "headers",                          "type": ["null","string"],  "default": null },
         { "name": "flag1",                            "type": ["null","boolean"], "default": null },

--- a/src/test/resources/header-mapping.groovy
+++ b/src/test/resources/header-mapping.groovy
@@ -19,8 +19,16 @@ mapping {
     map timestamp() onto 'ts'
     map remoteHost() onto 'remoteHost'
 
+    def hdrArr = header('X-Divolte-Test-Array', ', ')
+    map hdrArr.first() onto 'headerArrayFirst'
+    map hdrArr.last() onto 'headerArrayLast'
+    map hdrArr.get(-2) onto 'headerArraySecondLast'
+
     def hdr = header('X-Divolte-Test')
     map hdr onto 'headerList'
-    map hdr.first() onto 'header'
+    map hdr.first() onto 'headerFirst'
+    map hdr.get(1) onto 'headerGet'
+    map hdr.get(-2) onto 'headerSecondLast'
+    map hdr.last() onto 'headerLast'
     map hdr.commaSeparated() onto 'headers'
 }


### PR DESCRIPTION
Hi,

For extracting the IP from the list of the X-Forwarded-For field we need some additional operators. If you look at: https://cloud.google.com/compute/docs/load-balancing/http/
Then the `X-Forwarded-For` is an array of IP's, from which we want to extract the one on position -1:
`X-Forwarded-For: <unverified IP(s)>, <immediate client IP>, <global forwarding rule external IP>, <proxies running in GCP>`
```
----------------------------REQUEST---------------------------
               URI=/divolte/tt/web-event
 characterEncoding=null
     contentLength=-1
       contentType=null
            cookie=__cfduid=d790117bca575497c8d1131917e778b481515162912
            header=accept=text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8
            header=accept-language=en-US,en;q=0.9,nl;q=0.8
            header=cache-control=max-age=0
            header=accept-encoding=gzip, deflate, br
            header=X-Cloud-Trace-Context=9d65a86e7aa122147b4ac22af23062fd/4704248303183895011
            header=user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.162 Safari/537.36
            header=Via=1.1 google
            header=Connection=Keep-Alive
            header=X-Forwarded-Proto=https
            header=if-none-match="6b3edc43-20ec-4078-bc47-e965dd76b88a"
            header=X-Forwarded-For=145.58.117.28, 35.190.76.219
            header=cookie=__cfduid=d790117bca575497c8d1131917e778b481515162912
            header=upgrade-insecure-requests=1
            header=Host=xxx
            locale=[en_US, en, nl]
            method=GET
         parameter=c=jeye818a
         parameter=e=0:h1dmOKUi7BRzAvPA0Y81WF7ACR1tfBAg3
         parameter=f=f
         parameter=h=78
         parameter=i=1z4
         parameter=j=140
         parameter=k=1
          protocol=HTTP/1.1
       queryString=xxx
        remoteAddr=/10.132.0.5:50811
        remoteHost=xxx
            scheme=http
              host=xxx
        serverPort=8290
--------------------------RESPONSE--------------------------
     contentLength=-1
       contentType=image/gif
            header=Expires=Fri, 14 Apr 1995 11:30:00 GMT
            header=ETag="6b3edc43-20ec-4078-bc47-e965dd76b88a"
            header=Cache-Control=private, no-cache, proxy-revalidate
            header=Server=divolte
            header=Pragma=no-cache
            header=Content-Type=image/gif
            header=Date=Mon, 19 Mar 2018 15:49:48 GMT
            status=304
```

In this case we don't have a local proxy, so there are no more than two IP's in the `X-Forwarded-For` field, but if you are running a local squid proxy, you'll run into problems as with `.first()` you will catch the first field.

Cheers, Fokko