### PR TITLE
Respect divolte.global.gcs.{threads, buffer_size}

### DIFF
--- a/src/main/java/io/divolte/server/config/GoogleCloudStorageSinkConfiguration.java
+++ b/src/main/java/io/divolte/server/config/GoogleCloudStorageSinkConfiguration.java
@@ -61,7 +61,11 @@ public class GoogleCloudStorageSinkConfiguration extends FileSinkConfiguration {
             final Schema avroSchema = registry.getSchemaBySinkName(name).avroSchema;
             final FileManagerFactory fileManagerFactory = GoogleCloudStorageFileManager.newFactory(config, name, avroSchema);
             fileManagerFactory.verifyFileSystemConfiguration();
-            return new FileFlushingPool(config, name, fileManagerFactory);
+
+            final int threads = config.configuration().global.gcs.threads;
+            final int bufferSize = config.configuration().global.gcs.bufferSize;
+
+            return new FileFlushingPool(config, name, threads, bufferSize, fileManagerFactory);
         };
     }
 

--- a/src/main/java/io/divolte/server/config/HdfsSinkConfiguration.java
+++ b/src/main/java/io/divolte/server/config/HdfsSinkConfiguration.java
@@ -57,7 +57,11 @@ public class HdfsSinkConfiguration extends FileSinkConfiguration {
             final Schema avroschema = registry.getSchemaBySinkName(name).avroSchema;
             final FileManagerFactory fileManagerFactory = HdfsFileManager.newFactory(config, name, avroschema);
             fileManagerFactory.verifyFileSystemConfiguration();
-            return new FileFlushingPool(config, name, fileManagerFactory);
+
+            final int threads = config.configuration().global.hdfs.threads;
+            final int bufferSize = config.configuration().global.hdfs.bufferSize;
+
+            return new FileFlushingPool(config, name, threads, bufferSize, fileManagerFactory);
         };
     }
 

--- a/src/main/java/io/divolte/server/filesinks/FileFlushingPool.java
+++ b/src/main/java/io/divolte/server/filesinks/FileFlushingPool.java
@@ -27,16 +27,6 @@ import io.divolte.server.processing.ProcessingPool;
 
 @ParametersAreNonnullByDefault
 public class FileFlushingPool extends ProcessingPool<FileFlusher, AvroRecordBuffer> {
-    public FileFlushingPool(
-            final ValidatedConfiguration vc,
-            final String sinkName,
-            final FileManager.FileManagerFactory managerFactory) {
-        this(vc,
-             sinkName,
-             vc.configuration().global.hdfs.threads,
-             vc.configuration().global.hdfs.bufferSize,
-             managerFactory);
-    }
 
     public FileFlushingPool(
             final ValidatedConfiguration vc,


### PR DESCRIPTION
Take the divolte.global.gcs.{threads, buffer_size} properties into account. Currently for both hdfs and gcs the global hdfs properties are used.