### PR TITLE
Upgrade Hadoop dependencies to 3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     // Define some key versions for components that we use lots of artifacts from.
     // Note: we refer to the Avro documentation in our own documentation.
     def avroVersion = '1.8.2'
-    def hadoopVersion = '2.9.0'
+    def hadoopVersion = '3.1.0'
     def jacksonVersion = '2.9.5'
     def slf4jVersion = '1.7.25'
 

--- a/src/main/java/io/divolte/server/filesinks/hdfs/HdfsFileManager.java
+++ b/src/main/java/io/divolte/server/filesinks/hdfs/HdfsFileManager.java
@@ -16,13 +16,13 @@
 
 package io.divolte.server.filesinks.hdfs;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Objects;
-
-import javax.annotation.ParametersAreNonnullByDefault;
-
+import com.google.common.base.MoreObjects;
+import com.google.common.io.Closeables;
+import io.divolte.server.AvroRecordBuffer;
+import io.divolte.server.config.FileSinkConfiguration;
+import io.divolte.server.config.HdfsSinkConfiguration;
+import io.divolte.server.config.ValidatedConfiguration;
+import io.divolte.server.filesinks.FileManager;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -31,18 +31,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.mortbay.log.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.MoreObjects;
-
-import io.divolte.server.AvroRecordBuffer;
-import io.divolte.server.config.FileSinkConfiguration;
-import io.divolte.server.config.HdfsSinkConfiguration;
-import io.divolte.server.config.ValidatedConfiguration;
-import io.divolte.server.filesinks.FileManager;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Objects;
 
 @ParametersAreNonnullByDefault
 public class HdfsFileManager implements FileManager {
@@ -123,7 +119,7 @@ public class HdfsFileManager implements FileManager {
 
         @Override
         public void discard() throws IOException {
-            closeQuitely(writer);
+            Closeables.close(writer, true);
 
             if (hdfs.exists(inflightPath)) {
                 hdfs.delete(inflightPath, false);
@@ -221,14 +217,6 @@ public class HdfsFileManager implements FileManager {
             hdfsConfiguration.setBoolean("fs.automatic.close", false);
 
             return FileSystem.get(hdfsConfiguration);
-        }
-    }
-
-    private static void closeQuitely(final Closeable c) {
-        try {
-            c.close();
-        } catch (final IOException ioe) {
-            Log.warn("Failed to quietly close.", ioe);
         }
     }
 }


### PR DESCRIPTION
Normally dependency updates slide right in without a fuss so long as all the tests pass. This one is tricky though: we're upgrading from Hadoop 2.9 to 3.1 which is a major version bump.

As such this one will need testing against the major distributions to ensure everything works as we expect.