### PR TITLE
Fix JSON to Avro enumeration mapping

### DIFF
--- a/docs/mapping_reference.rst
+++ b/docs/mapping_reference.rst
@@ -1462,7 +1462,7 @@ Derived simple value: :samp:`header({name}).get({index})`
   from the incoming request. The first element in the list has an index of 0, the second is 1 and so on.
   If the position requested is negative, the position is relative to the *end* of the list. The last element in the list
   has an index of -1, the second last is -2 and so on.
-  
+
   No value is mapped if the specified position exceeds the bounds of the list of values.
 
 :Type:

--- a/docs/mapping_reference.rst
+++ b/docs/mapping_reference.rst
@@ -276,8 +276,8 @@ Some expressions, for example, :code:`eventParameters()` (and its :code:`path()`
 +-------------------+---------------------------------------------------------------------------+
 | | :code:`string`  | A JSON string, number or boolean value.                                   |
 +-------------------+---------------------------------------------------------------------------+
-| | :code:`enum`    | A JSON string, so long as the it's identical to one of the enumeration's  |
-|                   | symbols. (If not, the value will be treated as :code:`null`.              |
+| | :code:`enum`    | A JSON string, so long as it's identical to one of the enumeration's      |
+|                   | symbols. (If not, the value will be treated as :code:`null`).             |
 +-------------------+---------------------------------------------------------------------------+
 | | :code:`record`  | A JSON object, with each property corresponding to a field in the record. |
 |                   | (Extraneous properties are ignored.) The property values and field types  |

--- a/src/main/java/io/divolte/server/recordmapping/JacksonSupport.java
+++ b/src/main/java/io/divolte/server/recordmapping/JacksonSupport.java
@@ -18,6 +18,7 @@ package io.divolte.server.recordmapping;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -27,10 +28,13 @@ public class JacksonSupport {
         // Prevent external instantiation.
     }
 
-    static final AvroGenericRecordMapper AVRO_MAPPER =
-            new AvroGenericRecordMapper(
-                    new ObjectMapper().reader()
-                                      .with(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY,
-                                            DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
-                                      .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES));
+    private static final ObjectReader OBJECT_READER =
+        new ObjectMapper().reader()
+                          .with(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY,
+                                DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS)
+                          .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    static AvroGenericRecordMapper createAvroMapper() {
+        return new AvroGenericRecordMapper(OBJECT_READER);
+    }
 }

--- a/src/test/resources/io/divolte/server/recordmapping/jackson-mapping-fixtures.json
+++ b/src/test/resources/io/divolte/server/recordmapping/jackson-mapping-fixtures.json
@@ -338,7 +338,7 @@
         { "name": "baz", "type": "string" }
       ]
     },
-    "json": { "foo": "bar", "baz": "daz", "extraField": { "foo": "x", "baz": "y" }, "baz": "daz"},
+    "json": { "foo": "bar", "baz": "daz", "extraField": { "foo": "x", "baz": "y" }},
     "deserialization_features": {
       "FAIL_ON_UNKNOWN_PROPERTIES": false
     },

--- a/src/test/resources/io/divolte/server/recordmapping/jackson-mapping-fixtures.json
+++ b/src/test/resources/io/divolte/server/recordmapping/jackson-mapping-fixtures.json
@@ -106,11 +106,14 @@
   },
   {
     "title": "Test enum mapping missing value to null",
-    "schema": {
-      "type": "enum",
-      "name": "Suit",
-      "symbols": [ "SPADES", "HEARTS", "DIAMONDS", "CLUBS" ]
-    },
+    "schema": [
+      {
+        "type": "enum",
+        "name": "Suit",
+        "symbols": [ "SPADES", "HEARTS", "DIAMONDS", "CLUBS" ]
+      },
+      "null"
+    ],
     "json": "RAKES",
     "deserialization_features": {
       "READ_UNKNOWN_ENUM_VALUES_AS_NULL": true


### PR DESCRIPTION
This pull request fixes mapping JSON event parameters to Avro schemas that include enumeration fields. This was accidentally broken in when we upgraded to Avro 1.8.0, as discussed in #205.

It turns out we had a test for this situation, but it passed because the Avro error is only triggered during record serialisation. The tests have therefore been updated to also ensure that mapped records can be serialised.
