### PR TITLE
Fix avro-tools bundled with distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,6 @@ dependencies {
      * tested with these deps.
      */
     runtime (group: 'org.apache.avro', name: 'avro-tools', version: avroVersion, classifier: 'nodeps') {
-        exclude group: 'org.apache.avro', module: 'avro-ipc'
         exclude group: 'org.apache.avro', module: 'avro-mapred'
     }
 


### PR DESCRIPTION
As report in #204 the `avro-tools` command-line tool that we bundle doesn't work because it depends internally on `avro-ipc`. This used to be fine, but now it's not. (We were excluding this because we don't do any IPC and it pulls in even more unneeded transient dependencies.)

This pull request adds `avro-ipc` back into the distribution that we ship.