### PR TITLE
Return BooleanValueProducer instead of PrimitiveValueProducer<Boolean>

### DIFF
--- a/src/main/java/io/divolte/server/recordmapping/DslRecordMapping.java
+++ b/src/main/java/io/divolte/server/recordmapping/DslRecordMapping.java
@@ -238,7 +238,7 @@ public final class DslRecordMapping {
                 (e,c) -> source.produce(e, c).map(Doubles::tryParse));
     }
 
-    public ValueProducer<Boolean> toBoolean(final ValueProducer<String> source) {
+    public BooleanValueProducer toBoolean(final ValueProducer<String> source) {
         return new BooleanValueProducer(
                 "parse(" + source.identifier + " to bool)",
                 (e,c) -> source.produce(e, c).map(Boolean::parseBoolean));
@@ -259,15 +259,15 @@ public final class DslRecordMapping {
         return new PrimitiveValueProducer<>("eventType()", String.class, (e,c) -> e.eventType);
     }
 
-    public ValueProducer<Boolean> firstInSession() {
+    public BooleanValueProducer firstInSession() {
         return new BooleanValueProducer("firstInSession()", (e,c) -> Optional.of(e.firstInSession));
     }
 
-    public ValueProducer<Boolean> corrupt() {
+    public BooleanValueProducer corrupt() {
         return new BooleanValueProducer("corrupt()", (e,c) -> Optional.of(e.corruptEvent));
     }
 
-    public ValueProducer<Boolean> duplicate() {
+    public BooleanValueProducer duplicate() {
         return new BooleanValueProducer("duplicate()", (e,c) -> Optional.ofNullable(e.exchange.getAttachment(DUPLICATE_EVENT_KEY)));
     }
 
@@ -413,7 +413,7 @@ public final class DslRecordMapping {
                   true);
         }
 
-        public ValueProducer<Boolean> matches() {
+        public BooleanValueProducer matches() {
             return new BooleanValueProducer(identifier + ".matches()",
                                             (e,c) -> produce(e, c).map(Matcher::matches));
         }
@@ -940,14 +940,14 @@ public final class DslRecordMapping {
 
         @Deprecated
         @SuppressWarnings("deprecation")
-        public ValueProducer<Boolean> anonymousProxy() {
+        public BooleanValueProducer anonymousProxy() {
             return new BooleanValueProducer(identifier + ".anonymousProxy()",
                                             (e,c) -> produce(e, c).map(AbstractCountryResponse::getTraits).map(Traits::isAnonymousProxy));
         }
 
         @Deprecated
         @SuppressWarnings("deprecation")
-        public ValueProducer<Boolean> satelliteProvider() {
+        public BooleanValueProducer satelliteProvider() {
             return new BooleanValueProducer(identifier + ".satelliteProvider()",
                                             (e,c) -> produce(e, c).map(AbstractCountryResponse::getTraits).map(Traits::isSatelliteProvider));
         }
@@ -1057,13 +1057,13 @@ public final class DslRecordMapping {
             return result;
         }
 
-        public ValueProducer<Boolean> equalTo(final ValueProducer<T> other) {
+        public BooleanValueProducer equalTo(final ValueProducer<T> other) {
             return new BooleanValueProducer(
                     identifier + ".equalTo(" + other.identifier + ")",
                     (e,c) -> Optional.of(this.produce(e, c).equals(other.produce(e, c))));
         }
 
-        public ValueProducer<Boolean> equalTo(final T literal) {
+        public BooleanValueProducer equalTo(final T literal) {
             return new BooleanValueProducer(
                     identifier + ".equalTo(" + literal + ")",
                     (e,c) -> {
@@ -1072,16 +1072,14 @@ public final class DslRecordMapping {
                     });
         }
 
-        public ValueProducer<Boolean> isPresent() {
+        public BooleanValueProducer isPresent() {
             return new BooleanValueProducer(
                     identifier + ".isPresent()",
                     (e,c) -> Optional.of(produce(e, c).map((x) -> Boolean.TRUE).orElse(Boolean.FALSE)));
         }
 
-        public ValueProducer<Boolean> isAbsent() {
-            return new BooleanValueProducer(
-                    identifier + ".isAbsent()",
-                    (e,c) -> Optional.of(produce(e, c).map((x) -> Boolean.FALSE).orElse(Boolean.TRUE)));
+        public BooleanValueProducer isAbsent() {
+            return isPresent().negate();
         }
 
         abstract Optional<ValidationError> validateTypes(final Field target);
@@ -1163,7 +1161,7 @@ public final class DslRecordMapping {
             super(identifier, Boolean.class, supplier);
         }
 
-        public ValueProducer<Boolean> or(final ValueProducer<Boolean> other) {
+        public BooleanValueProducer or(final ValueProducer<Boolean> other) {
             return new BooleanValueProducer(
                     identifier + ".or(" + other.identifier + ")",
                     (e,c) -> {
@@ -1175,7 +1173,7 @@ public final class DslRecordMapping {
                     });
         }
 
-        public ValueProducer<Boolean> and(final ValueProducer<Boolean> other) {
+        public BooleanValueProducer and(final ValueProducer<Boolean> other) {
             return new BooleanValueProducer(
                     identifier + ".and(" + other.identifier + ")",
                     (e,c) -> {
@@ -1187,7 +1185,7 @@ public final class DslRecordMapping {
                     });
         }
 
-        public ValueProducer<Boolean> negate() {
+        public BooleanValueProducer negate() {
             return new BooleanValueProducer(
                         "not(" + identifier + ")",
                         (e,c) -> produce(e,c).map((b) -> !b));


### PR DESCRIPTION
Hi guys,

To become GDPR compliant we need to do mapping, and therefore we need to add some additional methods. For example, I would like to contribute some String operations (substr, length), and some hashing functions. I was familiarising myself with the Producers since I would like to add some more methods to do some parsing in the mapping. Whiled familiarising, I wondered why we use the `BooleanValueProducer` and then return a plain `ValueProducer<Boolean>`. If we return the `BooleanValueProducer`, we can also do some fancy stuff like the `negate()`. Refer to the code.

Cheers, Fokko