### PR TITLE
Fix string escaping in custom event parameters

### DIFF
--- a/src/main/resources/divolte.js
+++ b/src/main/resources/divolte.js
@@ -960,7 +960,7 @@ var AUTO_PAGE_VIEW_EVENT = true;
        * @const
        * @type {RegExp}
        */
-      var stringEscapingRegex = /~!/g;
+      var stringEscapingRegex = /[~!]/g;
       return function(s) {
         return s.replace(stringEscapingRegex, "~$&");
       }

--- a/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
+++ b/src/test/java/io/divolte/server/SeleniumJavaScriptTest.java
@@ -272,6 +272,7 @@ public class SeleniumJavaScriptTest extends SeleniumTestBase {
         assertTrue(customEventParameters.isPresent());
         assertEquals("{\"a\":{}," +
                      "\"b\":\"c\"," +
+                     "\"c\":\"A string with lots of things to escape\u2026 !+~?=;()-_[]<>%|^`&\\\"'\"," +
                      "\"d\":{\"a\":[],\"b\":\"g\"}," +
                      "\"e\":[\"1\",\"2\"]," +
                      "\"f\":42," +

--- a/src/test/resources/static/quirks/test-basic-page.html
+++ b/src/test/resources/static/quirks/test-basic-page.html
@@ -42,6 +42,7 @@
          onclick="divolte.signal('custom', {
                                    a: {},
                                    b: 'c',
+                                   c: 'A string with lots of things to escape\u2026 !+~?=;()-_[]<>%|^`&amp;&quot;\&apos;',
                                    d: { a: [], b: 'g' },
                                    e: [ '1', '2' ],
                                    f: 42,

--- a/src/test/resources/static/strict/test-basic-page.html
+++ b/src/test/resources/static/strict/test-basic-page.html
@@ -43,6 +43,7 @@
          onclick="divolte.signal('custom', {
                                    a: {},
                                    b: 'c',
+                                   c: 'A string with lots of things to escape\u2026 !+~?=;()-_[]<>%|^`&amp;&quot;\&apos;',
                                    d: { a: [], b: 'g' },
                                    e: [ '1', '2' ],
                                    f: 42,


### PR DESCRIPTION
This pull request fixes a bug in the encoding mechanism event parameters: tildes and exclamation marks weren't being correctly detected and escaped.

Resolves issue #221.