### PR TITLE
log Improper requests in debug level instead of info

### DIFF
--- a/src/main/java/io/divolte/server/ClientSideCookieEventHandler.java
+++ b/src/main/java/io/divolte/server/ClientSideCookieEventHandler.java
@@ -126,7 +126,7 @@ public final class ClientSideCookieEventHandler implements HttpHandler {
                 logEvent(exchange);
             } catch (final IncompleteRequestException ire) {
                 // improper request, could be anything
-                logger.warn("Improper request received from {}.", Optional.ofNullable(exchange.getSourceAddress()).map(InetSocketAddress::getHostString).orElse("<UNKNOWN HOST>"));
+                logger.debug("Improper request received from {}.", Optional.ofNullable(exchange.getSourceAddress()).map(InetSocketAddress::getHostString).orElse("<UNKNOWN HOST>"));
             }
         } else {
             if (logger.isDebugEnabled()) {

--- a/src/main/java/io/divolte/server/IncomingRequestProcessor.java
+++ b/src/main/java/io/divolte/server/IncomingRequestProcessor.java
@@ -143,7 +143,7 @@ public final class IncomingRequestProcessor implements ItemProcessor<UndertowEve
         try {
             event = item.payload.parseRequest();
         } catch (final IncompleteRequestException e) {
-            logger.warn("Improper request received from {}.", Optional.ofNullable(item.payload.exchange.getSourceAddress()).map(InetSocketAddress::getHostString).orElse("<UNKNOWN HOST>"));
+            logger.debug("Improper request received from {}.", Optional.ofNullable(item.payload.exchange.getSourceAddress()).map(InetSocketAddress::getHostString).orElse("<UNKNOWN HOST>"));
             return CONTINUE;
         }
 

--- a/src/main/java/io/divolte/server/JsonEventHandler.java
+++ b/src/main/java/io/divolte/server/JsonEventHandler.java
@@ -83,7 +83,7 @@ public class JsonEventHandler implements HttpHandler {
             } catch (final IncompleteRequestException e) {
                 // Improper request, could be anything.
                 exchange.setStatusCode(StatusCodes.BAD_REQUEST);
-                logger.warn("Improper request received from {}.",
+                logger.debug("Improper request received from {}.",
                             Optional.ofNullable(exchange.getSourceAddress())
                                     .map(InetSocketAddress::getHostString)
                                     .orElse("<UNKNOWN HOST>"));


### PR DESCRIPTION
log is flood with log messages about Improper requests. debug level sounds more reasonable for these situations.