### PR TITLE
Import ImmutableMap from Guava directly

### DIFF
--- a/src/test/java/io/divolte/server/JsonSourceTest.java
+++ b/src/test/java/io/divolte/server/JsonSourceTest.java
@@ -16,11 +16,11 @@
 
 package io.divolte.server;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import io.divolte.server.ServerTestUtils.TestServer;
 import io.divolte.server.config.JsonSourceConfiguration;
 import org.junit.After;


### PR DESCRIPTION
Instead of importing it from Avro's shaded version. The ImmutableMap might not be around anymore in Apache Avro 1.9... :-)