### PR TITLE
add hadoop-hdfs-client depency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ dependencies {
     compile (group: 'org.apache.hadoop', name:'hadoop-common', version: hadoopVersion) {
         exclude group: 'jline', module: 'jline'
     }
+    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: hadoopVersion
     compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: hadoopVersion
     compile (group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.15.0') {
         exclude group: 'com.google.guava', module: 'guava-jdk5'


### PR DESCRIPTION
Add hadoop-hdfs-client depency, this dependency is required to use HDFS as a sink