### PR TITLE
Support mapping native Avro timestamps.

### DIFF
--- a/config/findbugs/findbugs-excludes.xml
+++ b/config/findbugs/findbugs-excludes.xml
@@ -26,10 +26,18 @@
     </Match>
     <Match>
         <!--
-          ~ This method uses intentional fall-through from switch labels.
+          ~ These methods use intentional fall-through from switch labels.
           -->
-        <Class name="io.divolte.server.ChunkyByteBuffer"/>
-        <Method name="getBufferUsed"/>
+        <Or>
+            <And>
+                <Class name="io.divolte.server.ChunkyByteBuffer"/>
+                <Method name="getBufferUsed"/>
+            </And>
+            <And>
+                <Class name="io.divolte.server.ServerTestUtils$EventDecoder"/>
+                <Method name="decodeSchemaAsStrings"/>
+            </And>
+        </Or>
         <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
     </Match>
     <Match>

--- a/src/test/resources/MinimalRecord.avsc
+++ b/src/test/resources/MinimalRecord.avsc
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 GoDataDriven B.V.
+// Copyright 2019 GoDataDriven B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@
     "fields": [
         {
             "name": "ts",
-            "type": "long"
+            "type": {
+                "type": "long",
+                "logicalType": "timestamp-millis"
+            }
         },
         {
             "name": "session",

--- a/src/test/resources/TestRecord.avsc
+++ b/src/test/resources/TestRecord.avsc
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 GoDataDriven B.V.
+// Copyright 2019 GoDataDriven B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@
         { "name": "sessionStart",                    "type": "boolean" },
         { "name": "unreliable",                      "type": ["null","boolean"], "default": null },
         { "name": "dupe",                            "type": ["null","boolean"], "default": null },
-        { "name": "ts",                              "type": "long" },
+        { "name": "ts",                              "type": { "type": "long", "logicalType": "timestamp-millis" } },
+        { "name": "tsMicros",                        "type": ["null", { "type": "long", "logicalType": "timestamp-micros" } ], "default": null },
         { "name": "eventType",                       "type": ["null","string"],  "default": null },
         { "name": "userAgentString",                 "type": ["null","string"],  "default": null },
         { "name": "remoteHost",                      "type": "string" },

--- a/src/test/resources/timestamp-as-micros.groovy
+++ b/src/test/resources/timestamp-as-micros.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mapping {
+    map firstInSession() onto 'sessionStart'
+    map timestamp() onto 'ts'
+    map remoteHost() onto 'remoteHost'
+
+    map clientTimestamp() onto 'tsMicros'
+}

--- a/src/test/resources/timestamp-as-millis.groovy
+++ b/src/test/resources/timestamp-as-millis.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mapping {
+    map firstInSession() onto 'sessionStart'
+    map remoteHost() onto 'remoteHost'
+
+    map clientTimestamp() onto 'ts'
+}

--- a/src/test/resources/timestamp-from-long.groovy
+++ b/src/test/resources/timestamp-from-long.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 GoDataDriven B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mapping {
+    map firstInSession() onto 'sessionStart'
+    map remoteHost() onto 'remoteHost'
+
+    // Check that we can map a long onto a timestamp field.
+    map 1558101158679 onto 'ts'
+    map 1558101158679123 onto 'tsMicros'
+}


### PR DESCRIPTION
This pull request updates the `timestamp()` and `clientTimestamp()` providers to produce native timestamps that can be mapped to Avro fields with the timestamp logical types.

Such records are compatible with downstream consumers, but on the Divolte side schemas will need to be updated so that the timestamp fields have the correct logical types.

Documentation updates are also required.