### PR TITLE
Configure Travis to build more of our release artefacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ env:
   - DOCKER_CONTAINER=openjdk8
   - DOCKER_CONTAINER=openjdk11
 
-script: docker-compose run --rm $DOCKER_CONTAINER bash -c "./config/ci/install-schemas.sh && ./gradlew test"
+# TODO: User documentation (sphinx) and RPM (buildrpm et al.)
+script: docker-compose run --rm $DOCKER_CONTAINER bash -c "./config/ci/install-schemas.sh && ./gradlew build zip tarball"


### PR DESCRIPTION
The current Travis configuration runs the tests. It doesn't:

 - Build the release tarball/zip.
 - Build the RPM.
 - Build the documentation.

The documentation and RPM require tools (sphinx and build rpm) which aren't in our current Travis environment. However we can update our config to build more of the 'pure' gradle targets that we use. This brings it better into alignment with our existing Jenkins build.