### PR TITLE
Fix the Travis CI push-triggered builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,8 @@ env:
   - DOCKER_CONTAINER=openjdk8
   - DOCKER_CONTAINER=openjdk11
 
+git:
+    depth: false
+
 # TODO: User documentation (sphinx) and RPM (buildrpm et al.)
 script: docker-compose run --rm $DOCKER_CONTAINER bash -c "./config/ci/install-schemas.sh && ./gradlew build zip tarball"


### PR DESCRIPTION
These builds were failing due to the default clone settings used for push-triggered builds. By default only the last 50 commits are cloned, and this isn't always enough to include the most-recent version tag. When this happens the build can't figure its own version out and defaults to 0.1.0. Hilarity ensues.
