### PR TITLE
Upgrade Jackson to 2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     // Note: we refer to the Avro documentation in our own documentation.
     def avroVersion = '1.9.1'
     def hadoopVersion = '3.2.1'
-    def jacksonVersion = '2.9.10'
+    def jacksonVersion = '2.10.0'
     def slf4jVersion = '1.7.28'
 
     compile group: 'io.divolte', name: 'divolte-schema', version: version

--- a/src/main/java/io/divolte/server/JsonEventHandler.java
+++ b/src/main/java/io/divolte/server/JsonEventHandler.java
@@ -175,8 +175,8 @@ public class JsonEventHandler implements HttpHandler {
                 this.eventType          = Objects.requireNonNull(eventType);
                 this.sessionId          = Objects.requireNonNull(sessionId);
                 this.eventId            = Objects.requireNonNull(eventId);
-                this.isNewParty         = Objects.requireNonNull(isNewParty);
-                this.isNewSession       = Objects.requireNonNull(isNewSession);
+                this.isNewParty         = isNewParty;
+                this.isNewSession       = isNewSession;
                 this.clientTimestampIso = Objects.requireNonNull(clientTimestampIso);
                 this.parameters         = Objects.requireNonNull(parameters);
             }

--- a/src/main/java/io/divolte/server/mincode/MincodeFactory.java
+++ b/src/main/java/io/divolte/server/mincode/MincodeFactory.java
@@ -35,7 +35,7 @@ public class MincodeFactory extends JsonFactory {
     public final static Version FORMAT_VERSION = Version.unknownVersion();
 
     public MincodeFactory() {
-        this(null);
+        this((ObjectCodec) null);
     }
 
     public MincodeFactory(@Nullable final ObjectCodec oc) {
@@ -44,6 +44,10 @@ public class MincodeFactory extends JsonFactory {
 
     public MincodeFactory(final MincodeFactory src, @Nullable final ObjectCodec codec) {
         super(src, codec);
+    }
+
+    public MincodeFactory(final JsonFactoryBuilder builder) {
+        super(builder);
     }
 
     @Override

--- a/src/test/java/io/divolte/server/DslRecordMapperTest.java
+++ b/src/test/java/io/divolte/server/DslRecordMapperTest.java
@@ -624,7 +624,7 @@ public class DslRecordMapperTest {
                     .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
                     .setInjectableValues(new InjectableValues.Std().addValue("locales", ImmutableList.of("en")));
 
-    private <T> T loadFromClassPath(final String resource, final TypeReference<?> typeReference) throws IOException {
+    private <T> T loadFromClassPath(final String resource, final TypeReference<T> typeReference) throws IOException {
         try (final InputStream resourceStream = this.getClass().getResourceAsStream(resource)) {
             return MAPPER.readValue(resourceStream, typeReference);
         }

--- a/src/test/java/io/divolte/server/JsonSourceTest.java
+++ b/src/test/java/io/divolte/server/JsonSourceTest.java
@@ -367,6 +367,6 @@ public class JsonSourceTest {
         final DivolteEvent.JsonEventData jsonEventData = receivedEvent.jsonEventData.orElseThrow(AssertionError::new);
         assertNotNull(jsonEventData);
         final Optional<JsonNode> eventParameters = receivedEvent.eventParametersProducer.get();
-        assertFalse(eventParameters.isPresent());
+        assertFalse(eventParameters.filter(n -> !n.isNull()).isPresent());
     }
 }

--- a/src/test/java/io/divolte/server/mincode/MincodeFactoryTest.java
+++ b/src/test/java/io/divolte/server/mincode/MincodeFactoryTest.java
@@ -17,6 +17,7 @@
 package io.divolte.server.mincode;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.format.DataFormatDetector;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -27,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -81,7 +81,7 @@ public class MincodeFactoryTest {
         final byte[] bytes = MINCODE.getBytes(StandardCharsets.UTF_8);
         assertEquals(EXPECTED_STRING,
                      mincodeMapper.readValue(bytes, String.class));
-        mincodeMapper.getFactory().setInputDecorator(INVERTING_DECORATOR);
+        mincodeMapper = new ObjectMapper(new MincodeFactory(new JsonFactoryBuilder().inputDecorator(INVERTING_DECORATOR)));
         assertEquals(EXPECTED_STRING,
                      mincodeMapper.readValue(invert(bytes), String.class));
     }
@@ -129,12 +129,13 @@ public class MincodeFactoryTest {
     @Test
     public void testReadingFromCharArray() throws Exception {
         final char[] chars = MINCODE.toCharArray();
-        final JsonFactory factory = mincodeMapper.getFactory();
         assertEquals(EXPECTED_STRING,
-                     mincodeMapper.readValue(factory.createParser(chars), String.class));
-        factory.setInputDecorator(INVERTING_DECORATOR);
+                     mincodeMapper.readValue(mincodeMapper.getFactory().createParser(chars), String.class));
+
+        final JsonFactory invertedInputFactory = new MincodeFactory(new JsonFactoryBuilder().inputDecorator(INVERTING_DECORATOR));
+        mincodeMapper = new ObjectMapper(invertedInputFactory);
         assertEquals(EXPECTED_STRING,
-                     mincodeMapper.readValue(factory.createParser(invert(chars)), String.class));
+                     mincodeMapper.readValue(invertedInputFactory.createParser(invert(chars)), String.class));
     }
 
     @Test

--- a/src/test/java/io/divolte/server/mincode/MincodeParserTest.java
+++ b/src/test/java/io/divolte/server/mincode/MincodeParserTest.java
@@ -19,6 +19,7 @@ package io.divolte.server.mincode;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.exc.StreamReadException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
@@ -247,7 +248,7 @@ public class MincodeParserTest {
     private <T extends Number> void assertOutOfRange(final String expectedMessageSubstring,
                                                      final BigInteger maxValue,
                                                      final Class<T> type) throws IOException {
-        expectedException.expect(JsonParseException.class);
+        expectedException.expect(StreamReadException.class);
         expectedException.expectMessage(expectedMessageSubstring);
         MAPPER.readValue("j" + maxValue.add(BigInteger.ONE) + '!', type);
     }


### PR DESCRIPTION
Upgrading Jackson from 2.9 to 2.10 involves some source changes. This pull request includes them.