### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - DOCKER_CONTAINER=openjdk11
 
 git:
-    depth: false
+    depth: 3
 
 # TODO: User documentation (sphinx) and RPM (buildrpm et al.)
 script: docker-compose run --rm $DOCKER_CONTAINER bash -c "./config/ci/install-schemas.sh && ./gradlew build zip tarball"


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.